### PR TITLE
Fix empty iteration unless `seek_*` is explicitly called

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -56,6 +56,8 @@ where
             phantom: PhantomData,
         };
 
+        // We need an explicit `seek` call before we can start
+        // iterating.
         match direction {
             ScanDirection::Forward => iter.seek_to_first(),
             ScanDirection::Backward => iter.seek_to_last(),
@@ -110,6 +112,9 @@ where
             .with_label_values(&[S::COLUMN_FAMILY_NAME])
             .start_timer();
 
+        // SAFETY: Calling `next` or `prev` requires to check `valid` first.
+        // Not doing so may result in UB because of a nasty `rust-rocksdb` bug:
+        // <https://github.com/rust-rocksdb/rust-rocksdb/issues/824>.
         if !self.db_iter.valid() {
             self.db_iter.status()?;
             return Ok(None);

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -31,7 +31,7 @@ pub trait SeekKeyEncoder<S: Schema + ?Sized>: Sized {
 }
 
 /// Indicates in which direction iterator should be scanned.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub(crate) enum ScanDirection {
     Forward,
     Backward,
@@ -50,11 +50,18 @@ where
     S: Schema,
 {
     pub(crate) fn new(db_iter: rocksdb::DBRawIterator<'a>, direction: ScanDirection) -> Self {
-        SchemaIterator {
+        let mut iter = SchemaIterator {
             db_iter,
             direction,
             phantom: PhantomData,
-        }
+        };
+
+        match direction {
+            ScanDirection::Forward => iter.seek_to_first(),
+            ScanDirection::Backward => iter.seek_to_last(),
+        };
+
+        iter
     }
 
     /// Seeks to the first key.

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -469,10 +469,7 @@ mod tests {
                 for direction in [ScanDirection::Forward, ScanDirection::Backward] {
                     // Inverse
                     let err = db
-                        .raw_iter_range::<S>(
-                            upper_bound.clone()..lower_bound.clone(),
-                            direction.clone(),
-                        )
+                        .raw_iter_range::<S>(upper_bound.clone()..lower_bound.clone(), direction)
                         .err()
                         .unwrap();
                     assert_eq!("lower_bound > upper_bound", err.to_string());
@@ -556,10 +553,8 @@ mod tests {
             range: R,
         ) {
             for direction in [ScanDirection::Forward, ScanDirection::Backward] {
-                let iter_range = db
-                    .raw_iter_range::<S>(range.clone(), direction.clone())
-                    .unwrap();
-                validate_iterator(iter_range, range.clone(), direction.clone());
+                let iter_range = db.raw_iter_range::<S>(range.clone(), direction).unwrap();
+                validate_iterator(iter_range, range.clone(), direction);
             }
         }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,12 +6,12 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use crate::schema::{KeyDecoder, KeyEncoder, ValueCodec};
 use crate::{CodecError, Schema, SeekKeyEncoder};
 
+/// Key that is composed out of triplet of [`u32`]s.
 #[derive(Debug, Eq, PartialEq, Clone)]
-/// Key that composed out of tuple of r u32
 pub struct TestCompositeField(pub u32, pub u32, pub u32);
 
+/// Simple wrapper around [`u32`].
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-/// Simple value around u32
 pub struct TestField(pub u32);
 
 impl<S: Schema> KeyEncoder<S> for TestCompositeField {

--- a/tests/iterator_test.rs
+++ b/tests/iterator_test.rs
@@ -97,15 +97,26 @@ impl std::ops::Deref for TestDB {
 #[test]
 fn test_seek_to_first() {
     let db = TestDB::new();
+    let mut iter;
 
-    let mut iter = db.iter();
+    // Forward iterator from the beginning should return all values.
+    iter = db.iter();
     iter.seek_to_first();
     assert_eq!(
         collect_values(iter),
         [100, 102, 104, 110, 112, 114, 200, 202]
     );
 
-    let mut iter = db.rev_iter();
+    // Similarly, forward iterator *without an explicit seek call* should return
+    // all values.
+    iter = db.iter();
+    assert_eq!(
+        collect_values(iter),
+        [100, 102, 104, 110, 112, 114, 200, 202]
+    );
+
+    // Reverse iterator from the beginning should only return the first value.
+    iter = db.rev_iter();
     iter.seek_to_first();
     assert_eq!(collect_values(iter), [100]);
 }


### PR DESCRIPTION
Currently, `SchemaIterator` will return no contents at all without an explicit call to `seek_to_first`.

Iteration should instead result the whole column family contents by default, unless the user explicitly asks for something else by calling e.g. `seek(b"mykey")`.