### PR TITLE
Make `SchemaBatch::merge` public and `DB::write_schemas` borrow `SchemaBatch`

### DIFF
--- a/src/cache/cache_container.rs
+++ b/src/cache/cache_container.rs
@@ -10,7 +10,7 @@ use crate::iterator::ScanDirection;
 use crate::schema::{KeyCodec, ValueCodec};
 use crate::{Operation, RawDbIter, ReadOnlyLock, Schema, SchemaKey, SchemaValue, DB};
 
-/// Holds collection of [`ChangeSet`]'s associated with particular Snapshot
+/// Holds a collection of [`ChangeSet`]'s associated with particular Snapshot
 /// and knows how to traverse them.
 /// Managed externally.
 /// Should be managed carefully, because discrepancy between `snapshots` and `to_parent` leads to panic
@@ -71,7 +71,7 @@ impl CacheContainer {
         let snapshot = self.snapshots.remove(snapshot_id).ok_or_else(|| {
             anyhow::anyhow!("Attempt to commit unknown snapshot id={}", snapshot_id)
         })?;
-        self.db.write_schemas(snapshot.into())
+        self.db.write_schemas(&snapshot.into())
     }
 
     /// Indicates, if CacheContainer has any snapshots in memory.
@@ -481,7 +481,7 @@ mod tests {
         let mut db_data = SchemaBatch::new();
         db_data.put::<S>(&one, &one).unwrap();
         db_data.put::<S>(&three, &three).unwrap();
-        db.write_schemas(db_data).unwrap();
+        db.write_schemas(&db_data).unwrap();
 
         let snapshot_manager = Arc::new(RwLock::new(CacheContainer::new(db, to_parent.into())));
 
@@ -529,7 +529,7 @@ mod tests {
 
         let mut db_data = SchemaBatch::new();
         db_data.put::<S>(&f1, &f1).unwrap();
-        db.write_schemas(db_data).unwrap();
+        db.write_schemas(&db_data).unwrap();
 
         let snapshot_manager = Arc::new(RwLock::new(CacheContainer::new(db, to_parent.into())));
 
@@ -674,7 +674,7 @@ mod tests {
         db_data.put::<S>(&f4, &f1).unwrap();
         db_data.put::<S>(&f0, &f1).unwrap();
         db_data.put::<S>(&f11, &f9).unwrap();
-        db.write_schemas(db_data).unwrap();
+        db.write_schemas(&db_data).unwrap();
         // DB Data
         // | key | value |
         // |   3 |     9 |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl DB {
         // Used in tests only anyway.
         let mut batch = SchemaBatch::new();
         batch.put::<S>(key, value)?;
-        self.write_schemas(batch)
+        self.write_schemas(&batch)
     }
 
     /// Delete a single key from the database.
@@ -161,7 +161,7 @@ impl DB {
         // Used in tests only anyway.
         let mut batch = SchemaBatch::new();
         batch.delete::<S>(key)?;
-        self.write_schemas(batch)
+        self.write_schemas(&batch)
     }
 
     /// Removes the database entries in the range `["from", "to")` using default write options.
@@ -229,7 +229,7 @@ impl DB {
     }
 
     /// Writes a group of records wrapped in a [`SchemaBatch`].
-    pub fn write_schemas(&self, batch: SchemaBatch) -> anyhow::Result<()> {
+    pub fn write_schemas(&self, batch: &SchemaBatch) -> anyhow::Result<()> {
         let _timer = SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS
             .with_label_values(&[self.name])
             .start_timer();

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -171,7 +171,7 @@ fn test_single_schema_batch() {
         .put::<TestSchema2>(&TestField(5), &TestField(5))
         .unwrap();
 
-    db.write_schemas(db_batch).unwrap();
+    db.write_schemas(&db_batch).unwrap();
 
     assert_eq!(
         collect_values::<TestSchema1>(&db),
@@ -198,7 +198,7 @@ fn test_two_schema_batches() {
         .put::<TestSchema1>(&TestField(2), &TestField(2))
         .unwrap();
     db_batch1.delete::<TestSchema1>(&TestField(2)).unwrap();
-    db.write_schemas(db_batch1).unwrap();
+    db.write_schemas(&db_batch1).unwrap();
 
     assert_eq!(
         collect_values::<TestSchema1>(&db),
@@ -216,7 +216,7 @@ fn test_two_schema_batches() {
     db_batch2
         .put::<TestSchema2>(&TestField(5), &TestField(5))
         .unwrap();
-    db.write_schemas(db_batch2).unwrap();
+    db.write_schemas(&db_batch2).unwrap();
 
     assert_eq!(
         collect_values::<TestSchema1>(&db),
@@ -292,7 +292,7 @@ fn test_report_size() {
         db_batch
             .put::<TestSchema2>(&TestField(i), &TestField(i))
             .unwrap();
-        db.write_schemas(db_batch).unwrap();
+        db.write_schemas(&db_batch).unwrap();
     }
 
     db.flush_cf("TestCF1").unwrap();


### PR DESCRIPTION
This PR prepares rockbound for future change in Storage sub-system.

* `SchemaBatch::merge` becomes public, so users can collapse 2 changes together.
* `DB::write_schemas` borrows, so it can be called with `Arc<SchemaBatch>`


Test for `SchemaBatch::merge` is added