### PR TITLE
Upgrading proptest-derive and setting less default features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ readme = "README.md"
 [dependencies]
 anyhow = "1"
 byteorder = { version = "1", default-features = true, optional = true }
-once_cell = "1"
-prometheus = { version = "0.13" }
+once_cell = { version = "1", default-features = false }
+prometheus = { version = "0.13", default-features = false }
 proptest = { version = "1", optional = true }
-proptest-derive = { version = "0.4", optional = true }
+proptest-derive = { version = "0.5", optional = true }
 rocksdb = { version = "0.22", features = ["lz4"], default-features = false }
 thiserror = "1"
 tracing = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 rockbound = { path = ".", features = ["test-utils"] }


### PR DESCRIPTION
So proptest-derive can be upgraded in SDK, which should allow upgrading proptest and remove 1 cargo audit warning