### PR TITLE
Straight-forward exposure pruning-related API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,6 +652,20 @@ impl DB {
         Ok(())
     }
 
+    /// Triggers compaction of a single column family by name, over its full key range.
+    /// Drops tombstones and reclaims space. Heavy: rewrites the column family.
+    ///
+    /// Unlike [`Self::trigger_compaction`], this targets a column family that has no
+    /// [`Schema`] type in scope (e.g. a raw, runtime-named CF).
+    #[tracing::instrument(skip_all, level = "error")]
+    pub fn compact_cf(&self, cf_name: &str) -> anyhow::Result<()> {
+        let handle = self.get_cf_handle(cf_name)?;
+        // This has no effect on cache state, so it's safe to call without the lock.
+        self.db
+            .compact_range_cf::<&[u8], &[u8]>(&handle, None, None);
+        Ok(())
+    }
+
     /// Returns the current RocksDB property value for the provided column family name
     /// and property name.
     #[tracing::instrument(skip_all, level = "error")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,18 +645,15 @@ impl DB {
     /// Trigger compaction. Primarily used for testing.
     #[tracing::instrument(skip_all, level = "error")]
     pub fn trigger_compaction<S: Schema>(&self) -> anyhow::Result<()> {
-        let cf_handle = self.get_cf_handle(S::COLUMN_FAMILY_NAME)?;
-        // This has no effect on cache state, so it's safe to call without the lock.
-        self.db
-            .compact_range_cf::<&[u8], &[u8]>(&cf_handle, None, None);
-        Ok(())
+        self.compact_cf(S::COLUMN_FAMILY_NAME)
     }
 
     /// Triggers compaction of a single column family by name, over its full key range.
     /// Drops tombstones and reclaims space. Heavy: rewrites the column family.
     ///
-    /// Unlike [`Self::trigger_compaction`], this targets a column family that has no
-    /// [`Schema`] type in scope (e.g. a raw, runtime-named CF).
+    /// Takes the column family name directly, for callers that have a raw, runtime-named
+    /// CF rather than a [`Schema`] type in scope; [`Self::trigger_compaction`] is the
+    /// `Schema`-typed equivalent.
     #[tracing::instrument(skip_all, level = "error")]
     pub fn compact_cf(&self, cf_name: &str) -> anyhow::Result<()> {
         let handle = self.get_cf_handle(cf_name)?;

--- a/src/schema_batch.rs
+++ b/src/schema_batch.rs
@@ -189,8 +189,26 @@ impl<K: Ord, V> SchemaBatch<K, V> {
     ///
     /// Point writes are combined per key with last-write-wins (keys from `other` overwrite
     /// keys in `self`). Range deletes have no key to overwrite, so both batches' range
-    /// tombstones are retained (appended per column family).
-    pub fn merge(&mut self, other: SchemaBatch<K, V>) {
+    /// tombstones are retained (appended per column family). Earlier range tombstones are
+    /// split around later puts from `other` so those puts survive the merged write batch.
+    ///
+    /// The split is necessary because a written batch applies all point ops before all
+    /// range ops per column family (see [`crate::DB::update_db_batch_with_schema_data`]),
+    /// so within one batch a range tombstone always wins over an overlapping put. Splitting
+    /// `self`'s earlier ranges around `other`'s later puts restores last-write-wins across
+    /// the merge.
+    ///
+    /// The `K: Clone + Extend<u8>` bound exists only for that split: it lets us compute
+    /// the next key after a preserved put (see `range_delete_key_after`) so the re-emitted
+    /// ranges exclude exactly that key. In practice `K` is always [`SchemaKey`]
+    /// (`Vec<u8>`), which satisfies the bound; it is stated generically only because
+    /// `SchemaBatch` is generic over `K`.
+    pub fn merge(&mut self, other: SchemaBatch<K, V>)
+    where
+        K: Clone + Extend<u8>,
+    {
+        self.preserve_later_puts_from_earlier_range_ops(&other.last_writes);
+
         for (cf_name, other_cf_map) in other.last_writes {
             let cf_map = self.last_writes.entry(cf_name).or_default();
             cf_map.extend(other_cf_map);
@@ -200,6 +218,93 @@ impl<K: Ord, V> SchemaBatch<K, V> {
             cf_ops.extend(other_cf_ops);
         }
     }
+
+    fn preserve_later_puts_from_earlier_range_ops(
+        &mut self,
+        later_writes: &HashMap<ColumnFamilyName, BTreeMap<K, Operation<K, V>>>,
+    ) where
+        K: Clone + Extend<u8>,
+    {
+        for (cf_name, later_writes_for_cf) in later_writes {
+            if !later_writes_for_cf
+                .values()
+                .any(|operation| matches!(operation, Operation::Put { .. }))
+            {
+                continue;
+            }
+
+            let Some(range_ops) = self.range_ops.get_mut(cf_name) else {
+                continue;
+            };
+
+            let mut preserved_range_ops = Vec::with_capacity(range_ops.len());
+            for operation in std::mem::take(range_ops) {
+                match operation {
+                    Operation::DeleteRange { from, to } => {
+                        preserved_range_ops.extend(split_delete_range_around_later_puts(
+                            from,
+                            to,
+                            later_writes_for_cf,
+                        ));
+                    }
+                    operation => preserved_range_ops.push(operation),
+                }
+            }
+            *range_ops = preserved_range_ops;
+        }
+    }
+}
+
+fn split_delete_range_around_later_puts<K, V>(
+    from: K,
+    to: K,
+    later_writes: &BTreeMap<K, Operation<K, V>>,
+) -> Vec<Operation<K, V>>
+where
+    K: Ord + Clone + Extend<u8>,
+{
+    let mut ranges = vec![(from, to)];
+    for (key, operation) in later_writes {
+        if !matches!(operation, Operation::Put { .. }) {
+            continue;
+        }
+
+        let mut next_ranges = Vec::with_capacity(ranges.len() + 1);
+        for (from, to) in ranges {
+            if key < &from || key >= &to {
+                next_ranges.push((from, to));
+                continue;
+            }
+
+            if &from < key {
+                next_ranges.push((from, key.clone()));
+            }
+
+            let key_after = range_delete_key_after(key);
+            if key_after < to {
+                next_ranges.push((key_after, to));
+            }
+        }
+        ranges = next_ranges;
+    }
+
+    ranges
+        .into_iter()
+        .map(|(from, to)| Operation::DeleteRange { from, to })
+        .collect()
+}
+
+/// Returns the smallest key strictly greater than `key` under RocksDB's bytewise key
+/// ordering, computed as `key ++ 0x00`. Used by [`SchemaBatch::merge`] to re-emit a range
+/// delete that resumes just past a later put it must preserve. Requires `K: Extend<u8>`,
+/// which is the substantive reason `merge` carries that bound.
+fn range_delete_key_after<K>(key: &K) -> K
+where
+    K: Clone + Extend<u8>,
+{
+    let mut key_after = key.clone();
+    key_after.extend(std::iter::once(0));
+    key_after
 }
 
 #[cfg(feature = "arbitrary")]
@@ -480,6 +585,10 @@ mod tests {
 
         define_schema!(TestSchema2, TestField, TestField, "TestCF2");
 
+        fn encode_key(field: &TestField) -> SchemaKey {
+            <TestField as KeyEncoder<TestSchema1>>::encode_key(field).unwrap()
+        }
+
         #[test]
         fn test_simple_merge() {
             let field_1 = TestField(1);
@@ -562,6 +671,46 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .decode_value::<TestSchema2>()
+                    .unwrap()
+            );
+        }
+
+        #[test]
+        fn merge_splits_earlier_range_ops_around_later_puts() {
+            let (f1, f3, f5, f30) = (TestField(1), TestField(3), TestField(5), TestField(30));
+
+            let mut batch1 = SchemaBatch::new();
+            batch1.delete_range::<TestSchema1>(&f1, &f5).unwrap();
+
+            let mut batch2 = SchemaBatch::new();
+            batch2.put::<TestSchema1>(&f3, &f30).unwrap();
+
+            batch1.merge(batch2);
+
+            let f1_key = encode_key(&f1);
+            let f3_key = encode_key(&f3);
+            let f5_key = encode_key(&f5);
+            let expected = vec![
+                Operation::DeleteRange {
+                    from: f1_key,
+                    to: f3_key.clone(),
+                },
+                Operation::DeleteRange {
+                    from: range_delete_key_after(&f3_key),
+                    to: f5_key,
+                },
+            ];
+            assert_eq!(
+                Some(&expected),
+                batch1.range_ops.get(TestSchema1::COLUMN_FAMILY_NAME)
+            );
+            assert_eq!(
+                Some(f30),
+                batch1
+                    .get_operation::<TestSchema1>(&f3)
+                    .unwrap()
+                    .unwrap()
+                    .decode_value::<TestSchema1>()
                     .unwrap()
             );
         }

--- a/src/schema_batch.rs
+++ b/src/schema_batch.rs
@@ -56,11 +56,11 @@ impl SchemaBatch {
         from: &impl SeekKeyEncoder<S>,
         to: &impl SeekKeyEncoder<S>,
     ) -> anyhow::Result<()> {
-        let ops = self.range_ops.entry(S::COLUMN_FAMILY_NAME).or_default();
-        ops.push(Operation::DeleteRange {
-            from: from.encode_seek_key()?,
-            to: to.encode_seek_key()?,
-        });
+        self.push_range_op_cf(
+            S::COLUMN_FAMILY_NAME,
+            from.encode_seek_key()?,
+            to.encode_seek_key()?,
+        );
         Ok(())
     }
 
@@ -110,10 +110,7 @@ impl<K: Ord, V> SchemaBatch<K, V> {
     /// rather than from a `Schema` impl in scope. Mirrors [`Self::delete_raw`] but takes
     /// the CF name as an argument instead of inferring it from `S::COLUMN_FAMILY_NAME`.
     pub(crate) fn delete_cf_raw(&mut self, cf_name: ColumnFamilyName, key: K) {
-        self.last_writes
-            .entry(cf_name)
-            .or_default()
-            .insert(key, Operation::Delete);
+        self.insert_operation_cf(cf_name, key, Operation::Delete);
     }
 
     /// Add a put op against a column family known only at runtime.
@@ -122,10 +119,7 @@ impl<K: Ord, V> SchemaBatch<K, V> {
     /// rather than from a `Schema` impl in scope. Mirrors [`Self::put_raw`] but takes
     /// the CF name as an argument instead of inferring it from `S::COLUMN_FAMILY_NAME`.
     pub(crate) fn put_cf_raw(&mut self, cf_name: ColumnFamilyName, key: K, value: V) {
-        self.last_writes
-            .entry(cf_name)
-            .or_default()
-            .insert(key, Operation::Put { value });
+        self.insert_operation_cf(cf_name, key, Operation::Put { value });
     }
 
     /// Add a delete-range op against a column family known only at runtime.
@@ -135,15 +129,28 @@ impl<K: Ord, V> SchemaBatch<K, V> {
     /// The range is `[from, to)` (inclusive `from`, exclusive `to`), matching RocksDB's
     /// `delete_range_cf`.
     pub(crate) fn delete_range_cf_raw(&mut self, cf_name: ColumnFamilyName, from: K, to: K) {
+        self.push_range_op_cf(cf_name, from, to);
+    }
+
+    fn insert_operation<S: Schema>(&mut self, key: K, operation: Operation<K, V>) {
+        self.insert_operation_cf(S::COLUMN_FAMILY_NAME, key, operation);
+    }
+
+    fn insert_operation_cf(
+        &mut self,
+        cf_name: ColumnFamilyName,
+        key: K,
+        operation: Operation<K, V>,
+    ) {
+        let column_writes = self.last_writes.entry(cf_name).or_default();
+        column_writes.insert(key, operation);
+    }
+
+    fn push_range_op_cf(&mut self, cf_name: ColumnFamilyName, from: K, to: K) {
         self.range_ops
             .entry(cf_name)
             .or_default()
             .push(Operation::DeleteRange { from, to });
-    }
-
-    fn insert_operation<S: Schema>(&mut self, key: K, operation: Operation<K, V>) {
-        let column_writes = self.last_writes.entry(S::COLUMN_FAMILY_NAME).or_default();
-        column_writes.insert(key, operation);
     }
 
     /// Getting the operation from current schema batch if present

--- a/src/schema_batch.rs
+++ b/src/schema_batch.rs
@@ -104,6 +104,30 @@ impl<K: Ord, V> SchemaBatch<K, V> {
         Ok(())
     }
 
+    /// Add a delete op against a column family known only at runtime.
+    ///
+    /// Use this when the CF name comes from a trait constant or other runtime source
+    /// rather than from a `Schema` impl in scope. Mirrors [`Self::delete_raw`] but takes
+    /// the CF name as an argument instead of inferring it from `S::COLUMN_FAMILY_NAME`.
+    pub(crate) fn delete_cf_raw(&mut self, cf_name: ColumnFamilyName, key: K) {
+        self.last_writes
+            .entry(cf_name)
+            .or_default()
+            .insert(key, Operation::Delete);
+    }
+
+    /// Add a put op against a column family known only at runtime.
+    ///
+    /// Use this when the CF name comes from a trait constant or other runtime source
+    /// rather than from a `Schema` impl in scope. Mirrors [`Self::put_raw`] but takes
+    /// the CF name as an argument instead of inferring it from `S::COLUMN_FAMILY_NAME`.
+    pub(crate) fn put_cf_raw(&mut self, cf_name: ColumnFamilyName, key: K, value: V) {
+        self.last_writes
+            .entry(cf_name)
+            .or_default()
+            .insert(key, Operation::Put { value });
+    }
+
     fn insert_operation<S: Schema>(&mut self, key: K, operation: Operation<K, V>) {
         let column_writes = self.last_writes.entry(S::COLUMN_FAMILY_NAME).or_default();
         column_writes.insert(key, operation);

--- a/src/schema_batch.rs
+++ b/src/schema_batch.rs
@@ -13,6 +13,18 @@ pub struct SchemaBatch<K = SchemaKey, V = SchemaValue> {
     pub(crate) range_ops: HashMap<ColumnFamilyName, Vec<Operation<K, V>>>,
 }
 
+pub(crate) trait RangeDeleteKey: Ord + Clone {
+    fn range_delete_key_after(&self) -> Self;
+}
+
+impl RangeDeleteKey for SchemaKey {
+    fn range_delete_key_after(&self) -> Self {
+        let mut key_after = self.clone();
+        key_after.push(0);
+        key_after
+    }
+}
+
 impl<K, V> Default for SchemaBatch<K, V> {
     fn default() -> Self {
         Self {
@@ -190,7 +202,9 @@ impl<K: Ord, V> SchemaBatch<K, V> {
             .map(|column_writes| column_writes.range(range))
             .unwrap_or_default()
     }
+}
 
+impl<V> SchemaBatch<SchemaKey, V> {
     /// Merge other [`SchemaBatch`] on top of this one.
     ///
     /// Point writes are combined per key with last-write-wins (keys from `other` overwrite
@@ -203,18 +217,8 @@ impl<K: Ord, V> SchemaBatch<K, V> {
     /// so within one batch a range tombstone always wins over an overlapping put. Splitting
     /// `self`'s earlier ranges around `other`'s later puts restores last-write-wins across
     /// the merge.
-    ///
-    /// The `K: Clone + Extend<u8>` bound exists only for that split: it lets us compute
-    /// the next key after a preserved put (see `range_delete_key_after`) so the re-emitted
-    /// ranges exclude exactly that key. In practice `K` is always [`SchemaKey`]
-    /// (`Vec<u8>`), which satisfies the bound; it is stated generically only because
-    /// `SchemaBatch` is generic over `K`.
-    pub fn merge(&mut self, other: SchemaBatch<K, V>)
-    where
-        K: Clone + Extend<u8>,
-    {
-        self.preserve_later_puts_from_earlier_range_ops(&other.last_writes);
-
+    pub fn merge(&mut self, other: SchemaBatch<SchemaKey, V>) {
+        preserve_later_puts_from_earlier_range_ops(&mut self.range_ops, &other.last_writes);
         for (cf_name, other_cf_map) in other.last_writes {
             let cf_map = self.last_writes.entry(cf_name).or_default();
             cf_map.extend(other_cf_map);
@@ -224,40 +228,40 @@ impl<K: Ord, V> SchemaBatch<K, V> {
             cf_ops.extend(other_cf_ops);
         }
     }
+}
 
-    fn preserve_later_puts_from_earlier_range_ops(
-        &mut self,
-        later_writes: &HashMap<ColumnFamilyName, BTreeMap<K, Operation<K, V>>>,
-    ) where
-        K: Clone + Extend<u8>,
-    {
-        for (cf_name, later_writes_for_cf) in later_writes {
-            if !later_writes_for_cf
-                .values()
-                .any(|operation| matches!(operation, Operation::Put { .. }))
-            {
-                continue;
-            }
-
-            let Some(range_ops) = self.range_ops.get_mut(cf_name) else {
-                continue;
-            };
-
-            let mut preserved_range_ops = Vec::with_capacity(range_ops.len());
-            for operation in std::mem::take(range_ops) {
-                match operation {
-                    Operation::DeleteRange { from, to } => {
-                        preserved_range_ops.extend(split_delete_range_around_later_puts(
-                            from,
-                            to,
-                            later_writes_for_cf,
-                        ));
-                    }
-                    operation => preserved_range_ops.push(operation),
-                }
-            }
-            *range_ops = preserved_range_ops;
+fn preserve_later_puts_from_earlier_range_ops<K, V>(
+    range_ops_by_cf: &mut HashMap<ColumnFamilyName, Vec<Operation<K, V>>>,
+    later_writes: &HashMap<ColumnFamilyName, BTreeMap<K, Operation<K, V>>>,
+) where
+    K: RangeDeleteKey,
+{
+    for (cf_name, later_writes_for_cf) in later_writes {
+        if !later_writes_for_cf
+            .values()
+            .any(|operation| matches!(operation, Operation::Put { .. }))
+        {
+            continue;
         }
+
+        let Some(range_ops) = range_ops_by_cf.get_mut(cf_name) else {
+            continue;
+        };
+
+        let mut preserved_range_ops = Vec::with_capacity(range_ops.len());
+        for operation in std::mem::take(range_ops) {
+            match operation {
+                Operation::DeleteRange { from, to } => {
+                    preserved_range_ops.extend(split_delete_range_around_later_puts(
+                        from,
+                        to,
+                        later_writes_for_cf,
+                    ));
+                }
+                operation => preserved_range_ops.push(operation),
+            }
+        }
+        *range_ops = preserved_range_ops;
     }
 }
 
@@ -267,50 +271,38 @@ fn split_delete_range_around_later_puts<K, V>(
     later_writes: &BTreeMap<K, Operation<K, V>>,
 ) -> Vec<Operation<K, V>>
 where
-    K: Ord + Clone + Extend<u8>,
+    K: RangeDeleteKey,
 {
-    let mut ranges = vec![(from, to)];
-    for (key, operation) in later_writes {
+    if from >= to {
+        return Vec::new();
+    }
+
+    let mut ranges = Vec::new();
+    let mut next_from = from;
+
+    for (key, operation) in later_writes.range(next_from.clone()..to.clone()) {
         if !matches!(operation, Operation::Put { .. }) {
             continue;
         }
 
-        let mut next_ranges = Vec::with_capacity(ranges.len() + 1);
-        for (from, to) in ranges {
-            if key < &from || key >= &to {
-                next_ranges.push((from, to));
-                continue;
-            }
-
-            if &from < key {
-                next_ranges.push((from, key.clone()));
-            }
-
-            let key_after = range_delete_key_after(key);
-            if key_after < to {
-                next_ranges.push((key_after, to));
-            }
+        if next_from < *key {
+            ranges.push(Operation::DeleteRange {
+                from: next_from,
+                to: key.clone(),
+            });
         }
-        ranges = next_ranges;
+
+        next_from = key.range_delete_key_after();
+    }
+
+    if next_from < to {
+        ranges.push(Operation::DeleteRange {
+            from: next_from,
+            to,
+        });
     }
 
     ranges
-        .into_iter()
-        .map(|(from, to)| Operation::DeleteRange { from, to })
-        .collect()
-}
-
-/// Returns the smallest key strictly greater than `key` under RocksDB's bytewise key
-/// ordering, computed as `key ++ 0x00`. Used by [`SchemaBatch::merge`] to re-emit a range
-/// delete that resumes just past a later put it must preserve. Requires `K: Extend<u8>`,
-/// which is the substantive reason `merge` carries that bound.
-fn range_delete_key_after<K>(key: &K) -> K
-where
-    K: Clone + Extend<u8>,
-{
-    let mut key_after = key.clone();
-    key_after.extend(std::iter::once(0));
-    key_after
 }
 
 #[cfg(feature = "arbitrary")]
@@ -659,7 +651,7 @@ mod tests {
             let mut batch1 = SchemaBatch::new();
             batch1.delete_range::<TestSchema1>(&f1, &f2).unwrap();
 
-            // batch2: a range delete on CF1, one on CF2 (a CF absent from batch1 — a second
+            // batch2: a range delete on CF1, one on CF2 (a CF absent from batch1 - a second
             // namespace's pruning CF), plus a point write.
             let mut batch2 = SchemaBatch::new();
             batch2.delete_range::<TestSchema1>(&f2, &f3).unwrap();
@@ -719,7 +711,7 @@ mod tests {
                     to: f3_key.clone(),
                 },
                 Operation::DeleteRange {
-                    from: range_delete_key_after(&f3_key),
+                    from: f3_key.range_delete_key_after(),
                     to: f5_key,
                 },
             ];

--- a/src/schema_batch.rs
+++ b/src/schema_batch.rs
@@ -128,6 +128,19 @@ impl<K: Ord, V> SchemaBatch<K, V> {
             .insert(key, Operation::Put { value });
     }
 
+    /// Add a delete-range op against a column family known only at runtime.
+    ///
+    /// Mirrors [`Self::delete_range`] but takes the CF name as an argument and raw,
+    /// already-encoded bounds instead of inferring the CF from a `Schema` in scope.
+    /// The range is `[from, to)` (inclusive `from`, exclusive `to`), matching RocksDB's
+    /// `delete_range_cf`.
+    pub(crate) fn delete_range_cf_raw(&mut self, cf_name: ColumnFamilyName, from: K, to: K) {
+        self.range_ops
+            .entry(cf_name)
+            .or_default()
+            .push(Operation::DeleteRange { from, to });
+    }
+
     fn insert_operation<S: Schema>(&mut self, key: K, operation: Operation<K, V>) {
         let column_writes = self.last_writes.entry(S::COLUMN_FAMILY_NAME).or_default();
         column_writes.insert(key, operation);

--- a/src/schema_batch.rs
+++ b/src/schema_batch.rs
@@ -92,6 +92,12 @@ impl<K: Ord, V> SchemaBatch<K, V> {
         Self::default()
     }
 
+    /// Returns `true` if this batch has no point writes and no range operations.
+    pub fn is_empty(&self) -> bool {
+        self.last_writes.values().all(|writes| writes.is_empty())
+            && self.range_ops.values().all(|ops| ops.is_empty())
+    }
+
     /// Put a pre-encoded key and its value into the batch.
     pub fn put_raw<S: Schema>(&mut self, key: K, value: V) -> anyhow::Result<()> {
         let put_operation = Operation::Put { value };
@@ -371,6 +377,23 @@ mod tests {
     use crate::test::TestField;
 
     define_schema!(TestSchema1, TestField, TestField, "TestCF1");
+
+    #[test]
+    fn is_empty_tracks_point_and_range_ops() {
+        let mut batch = SchemaBatch::new();
+        assert!(batch.is_empty());
+
+        batch
+            .put::<TestSchema1>(&TestField(1), &TestField(10))
+            .unwrap();
+        assert!(!batch.is_empty());
+
+        let mut batch = SchemaBatch::new();
+        batch
+            .delete_range::<TestSchema1>(&TestField(1), &TestField(2))
+            .unwrap();
+        assert!(!batch.is_empty());
+    }
 
     mod range {
         use super::*;

--- a/src/schema_batch.rs
+++ b/src/schema_batch.rs
@@ -49,8 +49,9 @@ impl SchemaBatch {
 
     /// Adds a delete range operation to the batch.
     ///
-    /// Note: Range based operations aren't supported by iterators or merging,
-    /// which is consistent with rocksdb `WriteBatch`.
+    /// Note: Range based operations aren't reflected by the batch iterators
+    /// ([`SchemaBatch::iter`] / [`SchemaBatch::iter_range`]), consistent with rocksdb
+    /// `WriteBatch`. They are preserved by [`SchemaBatch::merge`].
     pub fn delete_range<S: Schema>(
         &mut self,
         from: &impl SeekKeyEncoder<S>,
@@ -185,11 +186,18 @@ impl<K: Ord, V> SchemaBatch<K, V> {
     }
 
     /// Merge other [`SchemaBatch`] on top of this one.
-    /// Keys from other will overwrite keys in self.
+    ///
+    /// Point writes are combined per key with last-write-wins (keys from `other` overwrite
+    /// keys in `self`). Range deletes have no key to overwrite, so both batches' range
+    /// tombstones are retained (appended per column family).
     pub fn merge(&mut self, other: SchemaBatch<K, V>) {
         for (cf_name, other_cf_map) in other.last_writes {
             let cf_map = self.last_writes.entry(cf_name).or_default();
             cf_map.extend(other_cf_map);
+        }
+        for (cf_name, other_cf_ops) in other.range_ops {
+            let cf_ops = self.range_ops.entry(cf_name).or_default();
+            cf_ops.extend(other_cf_ops);
         }
     }
 }
@@ -470,6 +478,8 @@ mod tests {
     mod merge {
         use super::*;
 
+        define_schema!(TestSchema2, TestField, TestField, "TestCF2");
+
         #[test]
         fn test_simple_merge() {
             let field_1 = TestField(1);
@@ -507,6 +517,53 @@ mod tests {
             );
             assert_eq!(Some(field_2), get_value(&field_4), "key (4) wasn't added");
             assert_eq!(None, get_value(&field_5), "key (5) wasn't deleted");
+        }
+
+        #[test]
+        fn merge_preserves_range_ops() {
+            let (f1, f2, f3) = (TestField(1), TestField(2), TestField(3));
+
+            // batch1: a range delete on CF1 (e.g. the user namespace's pruning CF).
+            let mut batch1 = SchemaBatch::new();
+            batch1.delete_range::<TestSchema1>(&f1, &f2).unwrap();
+
+            // batch2: a range delete on CF1, one on CF2 (a CF absent from batch1 — a second
+            // namespace's pruning CF), plus a point write.
+            let mut batch2 = SchemaBatch::new();
+            batch2.delete_range::<TestSchema1>(&f2, &f3).unwrap();
+            batch2.delete_range::<TestSchema2>(&f1, &f3).unwrap();
+            batch2.put::<TestSchema2>(&f1, &f2).unwrap();
+
+            batch1.merge(batch2);
+
+            // Same-CF range ops are concatenated (batch1's + batch2's).
+            assert_eq!(
+                batch1
+                    .range_ops
+                    .get(TestSchema1::COLUMN_FAMILY_NAME)
+                    .unwrap()
+                    .len(),
+                2
+            );
+            // The CF2 range op from `other` must NOT be dropped (the regression this guards).
+            assert_eq!(
+                batch1
+                    .range_ops
+                    .get(TestSchema2::COLUMN_FAMILY_NAME)
+                    .unwrap()
+                    .len(),
+                1
+            );
+            // Point ops still merge as before.
+            assert_eq!(
+                Some(f2),
+                batch1
+                    .get_operation::<TestSchema2>(&f1)
+                    .unwrap()
+                    .unwrap()
+                    .decode_value::<TestSchema2>()
+                    .unwrap()
+            );
         }
     }
 }

--- a/src/versioned_db.rs
+++ b/src/versioned_db.rs
@@ -389,6 +389,24 @@ impl KeyWithVersionPrefixAndSuffix {
     }
 }
 
+/// Encodes the historical/archival-CF key layout: `key` followed by the big-endian
+/// `version`. Mirrors `KeyWithVersionPrefixAndSuffix::archival_key`.
+fn encode_archival_key(key: &[u8], version: u64) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(key.len() + 8);
+    buf.extend_from_slice(key);
+    buf.extend_from_slice(&version.to_be_bytes());
+    buf
+}
+
+/// Encodes the pruning-CF key layout: the big-endian `version` followed by `key`.
+/// Mirrors `KeyWithVersionPrefixAndSuffix::pruning_key`.
+fn encode_pruning_key(version: u64, key: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(8 + key.len());
+    buf.extend_from_slice(&version.to_be_bytes());
+    buf.extend_from_slice(key);
+    buf
+}
+
 impl<V: SchemaWithVersion, C: CacheForVersionedDB<V>> VersionedDB<V, C>
 where
     V::Key: Ord + Clone + std::hash::Hash + AsRef<[u8]>,
@@ -565,7 +583,8 @@ where
     /// - writes [`VersionedTableMetadataKey::PrunedVersion`] = the greatest
     ///   `version - 1` for which this batch deleted a historical row, if any.
     ///
-    /// `keep_versions` must be `>= 1`. If the database has no committed version yet,
+    /// `keep_versions` must be `>= 1`. `max_batch_size`, when set, must be `>= 1`;
+    /// use `None` for an uncapped batch. If the database has no committed version yet,
     /// or if `last_committed < keep_versions`, the returned batch is empty and
     /// `last_pruned_version` is `None`.
     ///
@@ -580,6 +599,9 @@ where
         if keep_versions == 0 {
             anyhow::bail!("keep_versions must be >= 1");
         }
+        if max_batch_size == Some(0) {
+            anyhow::bail!("max_batch_size must be >= 1 when set");
+        }
 
         let mut batch = SchemaBatch::new();
         let mut keys_inspected = 0usize;
@@ -593,10 +615,10 @@ where
         else {
             return Ok(PruningBatchOutput {
                 batch,
-                hit_size_limit: false,
-                last_pruned_version: None,
-                keys_inspected: 0,
-                keys_to_prune: 0,
+                hit_size_limit,
+                last_pruned_version,
+                keys_inspected,
+                keys_to_prune,
             });
         };
 
@@ -619,8 +641,7 @@ where
             // entry per live key" invariant.
             if let Some(query_version) = version.checked_sub(1) {
                 if let Some(prev_version) = self.get_version_for_key(&key, query_version)? {
-                    let mut hist_key_bytes = key.as_ref().to_vec();
-                    hist_key_bytes.extend_from_slice(&prev_version.to_be_bytes());
+                    let hist_key_bytes = encode_archival_key(key.as_ref(), prev_version);
                     batch.delete_cf_raw(V::HISTORICAL_COLUMN_FAMILY_NAME, hist_key_bytes);
                     keys_to_prune += 1;
                     last_pruned_version = Some(query_version);
@@ -632,9 +653,7 @@ where
                 // Stop the pruning-CF range at this entry (exclusive): everything strictly
                 // before it was fully processed this pass; this entry and any later ones
                 // keep their pruning index until a subsequent pass re-visits them.
-                let mut bound = version.to_be_bytes().to_vec();
-                bound.extend_from_slice(key.as_ref());
-                pruning_cf_upper = bound;
+                pruning_cf_upper = encode_pruning_key(version, key.as_ref());
                 break;
             }
         }

--- a/src/versioned_db.rs
+++ b/src/versioned_db.rs
@@ -584,8 +584,8 @@ where
     ///
     /// `keep_versions` must be `>= 1`. `max_batch_size`, when set, must be `>= 1`;
     /// use `None` for an uncapped batch. If the database has no committed version yet,
-    /// or if `last_committed < keep_versions`, the returned batch is empty and
-    /// `last_pruned_version` is `None`.
+    /// if `last_committed < keep_versions`, or if no pruning entries remain up to the
+    /// cutoff, the returned batch is empty and `last_pruned_version` is `None`.
     ///
     /// When `max_batch_size` is set, at most that many pruning entries are collected per
     /// pass, so the batch holds at most that many historical-CF deletes (each entry
@@ -707,9 +707,11 @@ where
             prev_in_group = Some((key.as_ref(), *version));
         }
 
-        // Clear the collected pruning entries with one range tombstone over
-        // `[start-of-CF, pruning_cf_upper)`. `Vec::new()` sorts before all keys.
-        batch.delete_range_cf_raw(V::PRUNING_COLUMN_FAMILY_NAME, Vec::new(), pruning_cf_upper);
+        if keys_inspected > 0 {
+            // Clear the collected pruning entries with one range tombstone over
+            // `[start-of-CF, pruning_cf_upper)`. `Vec::new()` sorts before all keys.
+            batch.delete_range_cf_raw(V::PRUNING_COLUMN_FAMILY_NAME, Vec::new(), pruning_cf_upper);
+        }
 
         if let Some(v) = last_pruned_version {
             batch.put_cf_raw(

--- a/src/versioned_db.rs
+++ b/src/versioned_db.rs
@@ -19,7 +19,7 @@ use crate::{
     iterator::{RawDbIter, ScanDirection},
     metrics::{SCHEMADB_BATCH_COMMIT_BYTES, SCHEMADB_DELETES, SCHEMADB_PUT_BYTES},
     schema::{ColumnFamilyName, KeyDecoder, KeyEncoder, ValueCodec},
-    BasicWeighter, CacheForSchema, CfDescriptorBuilder, CodecError, Schema, DB,
+    BasicWeighter, CacheForSchema, CfDescriptorBuilder, CodecError, Schema, SchemaBatch, DB,
 };
 
 #[derive(Debug, Default)]
@@ -37,7 +37,7 @@ impl Schema for VersionMetadata {
 pub enum VersionedTableMetadataKey {
     /// The latest version that has been committed.
     CommittedVersion,
-    /// The newest version that has been pruned.
+    /// The newest version historical readers should treat as pruned.
     PrunedVersion,
 }
 
@@ -181,7 +181,9 @@ fn decode_version_metadata_value(data: &[u8]) -> Result<u64, CodecError> {
 impl<S: SchemaWithVersion, C: CacheForVersionedDB<S>> VersionedDB<S, C>
 // This where clause shouldn't be needed since it's implied by the Schema trait, but Rust intentionally doesn't elaborate these bounds.
 {
-    /// Returns the oldest version that is available in the database.
+    /// Returns the newest version historical readers should treat as pruned.
+    ///
+    /// Historical reads use `pruned_version + 1` as the oldest available version.
     pub fn get_pruned_version(&self) -> anyhow::Result<Option<u64>> {
         self.archival_db.get_raw_with_cf_and_decoder::<u64>(
             S::VERSION_METADATA_COLUMN_FAMILY_NAME,
@@ -531,6 +533,99 @@ where
             )
     }
 
+    /// Collects a batch of deletes that prunes versioned data older than
+    /// `last_committed - keep_versions`. The returned batch targets the `archival_db`:
+    /// the caller commits it via `archival_db.write_schemas(&output.batch)`.
+    ///
+    /// On commit, the batch:
+    /// - deletes pruning-CF entries `[V|K]` with `V <= cutoff` for every visited key,
+    /// - deletes the historical-CF entry of the *previous* write of each such K (so the
+    ///   most recent write at or before `cutoff` survives, preserving the invariant
+    ///   that every live key has at least one historical entry; see the doc on
+    ///   [`VersionedDB`]),
+    /// - writes [`VersionedTableMetadataKey::PrunedVersion`] = the greatest
+    ///   `version - 1` for which this batch deleted a historical row, if any.
+    ///
+    /// `keep_versions` must be `>= 1`. If the database has no committed version yet,
+    /// or if `last_committed < keep_versions`, the returned batch is empty and
+    /// `last_pruned_version` is `None`.
+    ///
+    /// When `max_batch_size` is set, iteration stops once that many historical-CF
+    /// deletes have been collected; `hit_size_limit` is then `true` and the caller
+    /// should commit the batch and re-invoke to drain the rest.
+    pub fn collect_pruning_batch(
+        &self,
+        keep_versions: u64,
+        max_batch_size: Option<usize>,
+    ) -> anyhow::Result<PruningBatchOutput> {
+        if keep_versions == 0 {
+            anyhow::bail!("keep_versions must be >= 1");
+        }
+
+        let mut batch = SchemaBatch::new();
+        let mut keys_inspected = 0usize;
+        let mut keys_to_prune = 0usize;
+        let mut hit_size_limit = false;
+        let mut last_pruned_version = None;
+
+        let Some(cutoff) = self
+            .get_committed_version_live_db()?
+            .and_then(|last_committed| last_committed.checked_sub(keep_versions))
+        else {
+            return Ok(PruningBatchOutput {
+                batch,
+                hit_size_limit: false,
+                last_pruned_version: None,
+                keys_inspected: 0,
+                keys_to_prune: 0,
+            });
+        };
+
+        for prunable in self.iter_pruning_keys_up_to_version(cutoff)? {
+            keys_inspected += 1;
+            let (version, key) = prunable.version_and_key();
+
+            let mut pruning_key_bytes = version.to_be_bytes().to_vec();
+            pruning_key_bytes.extend_from_slice(key.as_ref());
+            batch.delete_cf_raw(V::PRUNING_COLUMN_FAMILY_NAME, pruning_key_bytes);
+
+            // Look up the previous version of this key and delete that historical entry,
+            // keeping the entry at `version` intact. When `version == 0` or the key has no
+            // earlier write, leave the historical CF alone — preserves the "at least one
+            // entry per live key" invariant.
+            if let Some(query_version) = version.checked_sub(1) {
+                if let Some(prev_version) = self.get_version_for_key(&key, query_version)? {
+                    let mut hist_key_bytes = key.as_ref().to_vec();
+                    hist_key_bytes.extend_from_slice(&prev_version.to_be_bytes());
+                    batch.delete_cf_raw(V::HISTORICAL_COLUMN_FAMILY_NAME, hist_key_bytes);
+                    keys_to_prune += 1;
+                    last_pruned_version = Some(query_version);
+                }
+            }
+
+            if max_batch_size.is_some_and(|m| keys_to_prune >= m) {
+                hit_size_limit = true;
+                break;
+            }
+        }
+
+        if let Some(v) = last_pruned_version {
+            batch.put_cf_raw(
+                V::VERSION_METADATA_COLUMN_FAMILY_NAME,
+                VersionedTableMetadataKey::PrunedVersion.as_bytes().to_vec(),
+                v.to_be_bytes().to_vec(),
+            );
+        }
+
+        Ok(PruningBatchOutput {
+            batch,
+            hit_size_limit,
+            last_pruned_version,
+            keys_inspected,
+            keys_to_prune,
+        })
+    }
+
     fn load_committed_version_from_disk(live_db: &DB) -> anyhow::Result<Option<u64>> {
         live_db.get_raw_with_cf_and_decoder::<u64>(
             V::VERSION_METADATA_COLUMN_FAMILY_NAME,
@@ -801,6 +896,25 @@ pub struct VersionedDbMetrics {
     pub deletes: usize,
     pub archival_puts_bytes: usize,
     pub pruning_puts_bytes: usize,
+}
+
+/// Output of [`VersionedDB::collect_pruning_batch`].
+///
+/// The caller commits `batch` via `archival_db.write_schemas(&output.batch)`.
+#[derive(Debug)]
+pub struct PruningBatchOutput {
+    /// Multi-CF batch of deletes and the metadata write.
+    pub batch: SchemaBatch,
+    /// `true` if iteration stopped because `max_batch_size` was reached. Caller should
+    /// commit and re-invoke until this returns `false`.
+    pub hit_size_limit: bool,
+    /// The value recorded into [`VersionedTableMetadataKey::PrunedVersion`], or `None`
+    /// when this batch deleted no historical rows.
+    pub last_pruned_version: Option<u64>,
+    /// Number of pruning-CF entries the iterator visited. For metrics.
+    pub keys_inspected: usize,
+    /// Number of historical-CF delete operations placed in the batch. For metrics.
+    pub keys_to_prune: usize,
 }
 
 #[derive(Debug, Clone)]

--- a/src/versioned_db.rs
+++ b/src/versioned_db.rs
@@ -570,13 +570,12 @@ where
     /// the caller commits it via `archival_db.write_schemas(&output.batch)`.
     ///
     /// On commit, the batch:
-    /// - clears pruning-CF entries `[V|K]` with `V <= cutoff` using a single range
-    ///   tombstone, bounded at the point where this pass stopped (see `max_batch_size`
-    ///   below). The bound never reaches past a pruning entry whose historical predecessor
-    ///   delete wasn't also emitted this pass — otherwise that historical row would be
-    ///   orphaned (its pruning index gone) and never reclaimed.
-    /// - deletes the historical-CF entry of the *previous* write of each visited K (so the
-    ///   most recent write at or before `cutoff` survives, preserving the invariant
+    /// - clears the pruning-CF entries `[V|K]` (`V <= cutoff`) collected this pass using
+    ///   a single range tombstone. Every collected entry has its historical predecessor
+    ///   delete emitted in this same batch, so the tombstone covers all of them; entries
+    ///   beyond the `max_batch_size` cap stay in the pruning index for later passes.
+    /// - deletes the historical-CF entry of the *previous* write of each collected K (so
+    ///   the most recent write at or before `cutoff` survives, preserving the invariant
     ///   that every live key has at least one historical entry; see the doc on
     ///   [`VersionedDB`]). These stay point deletes — they are scattered per-key and not
     ///   safely range-able; their space is reclaimed by [`VersionedDB::trigger_compaction`].
@@ -588,9 +587,20 @@ where
     /// or if `last_committed < keep_versions`, the returned batch is empty and
     /// `last_pruned_version` is `None`.
     ///
-    /// When `max_batch_size` is set, iteration stops once that many historical-CF
-    /// deletes have been collected; `hit_size_limit` is then `true` and the caller
-    /// should commit the batch and re-invoke to drain the rest.
+    /// When `max_batch_size` is set, at most that many pruning entries are collected per
+    /// pass, so the batch holds at most that many historical-CF deletes (each entry
+    /// contributes at most one); `hit_size_limit` is `true` when entries remain beyond
+    /// the cap, and the caller should commit the batch and re-invoke to drain the rest.
+    ///
+    /// # Performance
+    ///
+    /// One sequential scan of the pruning index over the collected entries, plus at most
+    /// one historical-CF seek per *distinct key* in the pass: within a key's group of
+    /// collected versions every predecessor is known from the group itself, and only the
+    /// group's oldest version needs a lookup (for a survivor left by an earlier pass).
+    /// An uncapped pass buffers all prunable entries in memory (the same order of
+    /// magnitude as the returned batch itself); set `max_batch_size` to bound memory and
+    /// commit size when pruning a large backlog.
     pub fn collect_pruning_batch(
         &self,
         keep_versions: u64,
@@ -604,7 +614,6 @@ where
         }
 
         let mut batch = SchemaBatch::new();
-        let mut keys_inspected = 0usize;
         let mut keys_to_prune = 0usize;
         let mut hit_size_limit = false;
         let mut last_pruned_version = None;
@@ -617,48 +626,88 @@ where
                 batch,
                 hit_size_limit,
                 last_pruned_version,
-                keys_inspected,
+                keys_inspected: 0,
                 keys_to_prune,
             });
         };
 
-        // The pruning CF is keyed `[version_be || key]` and every entry we visit has
-        // `version <= cutoff`, so the visited set is one contiguous prefix range that we
-        // clear with a single range tombstone (after the loop) instead of one point delete
-        // per entry. `pruning_cf_upper` is the exclusive upper bound of that range: it
-        // starts at `first_version_to_keep` (covers everything `<= cutoff`) and, if we stop
-        // early on `max_batch_size`, is pulled back to the stopping point so we never drop a
-        // pruning entry whose historical predecessor delete wasn't also emitted this pass.
-        let mut pruning_cf_upper = cutoff.saturating_add(1).to_be_bytes().to_vec();
-
-        for prunable in self.iter_pruning_keys_up_to_version(cutoff)? {
-            keys_inspected += 1;
-            let (version, key) = prunable.version_and_key();
-
-            // Look up the previous version of this key and delete that historical entry,
-            // keeping the entry at `version` intact. When `version == 0` or the key has no
-            // earlier write, leave the historical CF alone — preserves the "at least one
-            // entry per live key" invariant.
-            if let Some(query_version) = version.checked_sub(1) {
-                if let Some(prev_version) = self.get_version_for_key(&key, query_version)? {
-                    let hist_key_bytes = encode_archival_key(key.as_ref(), prev_version);
-                    batch.delete_cf_raw(V::HISTORICAL_COLUMN_FAMILY_NAME, hist_key_bytes);
-                    keys_to_prune += 1;
-                    last_pruned_version = Some(query_version);
-                }
-            }
-
-            if max_batch_size.is_some_and(|m| keys_to_prune >= m) {
-                hit_size_limit = true;
-                // Stop the pruning-CF range at this entry (exclusive): everything strictly
-                // before it was fully processed this pass; this entry and any later ones
-                // keep their pruning index until a subsequent pass re-visits them.
-                pruning_cf_upper = encode_pruning_key(version, key.as_ref());
+        // Phase 1: collect up to `max_batch_size` pruning entries `[V|K]` with
+        // `V <= cutoff`, in `[version_be || key]` order. Bounding the collection bounds
+        // both this pass's memory and the number of deletes emitted below (each entry
+        // contributes at most one historical delete).
+        let mut iter = self.iter_pruning_keys_up_to_version(cutoff)?;
+        let mut collected: Vec<(u64, V::Key)> = Vec::new();
+        for prunable in &mut iter {
+            collected.push(prunable.version_and_key());
+            if max_batch_size.is_some_and(|m| collected.len() >= m) {
+                // Peek whether entries remain so callers know to re-invoke.
+                hit_size_limit = iter.next().is_some();
                 break;
             }
         }
+        let keys_inspected = collected.len();
 
-        // Collapse the per-entry pruning-CF deletes into one range tombstone over
+        // The pruning CF is keyed `[version_be || key]` and every collected entry has
+        // `version <= cutoff`, so the collected set is one contiguous prefix range that we
+        // clear with a single range tombstone instead of one point delete per entry. Every
+        // collected entry is fully processed below (its historical predecessor delete is
+        // emitted in this same batch), so the tombstone may cover all of them: when the
+        // iterator was drained, the exclusive upper bound is `cutoff + 1`; when we stopped
+        // at `max_batch_size`, it is the successor of the last collected entry.
+        let pruning_cf_upper = if hit_size_limit {
+            let (last_version, last_key) = collected
+                .last()
+                .expect("hit_size_limit implies at least one collected entry");
+            let mut upper = encode_pruning_key(*last_version, last_key.as_ref());
+            // Appending 0x00 yields the smallest key strictly greater under bytewise
+            // ordering, making the bound inclusive of the last collected entry.
+            upper.push(0);
+            upper
+        } else {
+            cutoff.saturating_add(1).to_be_bytes().to_vec()
+        };
+
+        // Phase 2: group the collected entries per key, versions ascending within each
+        // group. Sort by key *bytes* to match the column family's ordering.
+        collected
+            .sort_unstable_by(|(va, ka), (vb, kb)| ka.as_ref().cmp(kb.as_ref()).then(va.cmp(vb)));
+
+        // Phase 3: walk each key's group `[V1 < V2 < ... < Vm]` and delete the historical
+        // entry of each version's *previous* write, keeping the entry at `Vm` (the most
+        // recent write at or before `cutoff`) intact — preserves the "at least one entry
+        // per live key" invariant; see the doc on [`VersionedDB`].
+        //
+        // For `Vi` with `i >= 2` the previous write is `V(i-1)`, known from the group
+        // itself. Only `V1` needs a historical-CF lookup: its previous write, if any, is a
+        // survivor kept by an earlier pass. (A pre-redesign capped pass may also have left
+        // `V1` lingering with its predecessor already deleted; the lookup then finds
+        // nothing and emits nothing, so passes of either vintage compose safely.) When
+        // `V1 == 0` there is nothing before it and the lookup is skipped.
+        let mut prev_in_group: Option<(&[u8], u64)> = None;
+        for (version, key) in &collected {
+            // Deleting this entry's predecessor redirects historical queries in
+            // `[predecessor, version - 1]`; `version == 0` has no predecessor.
+            let Some(query_version) = version.checked_sub(1) else {
+                prev_in_group = Some((key.as_ref(), *version));
+                continue;
+            };
+            let prev_version = match prev_in_group {
+                Some((prev_key, prev_version)) if prev_key == key.as_ref() => Some(prev_version),
+                _ => self.get_version_for_key(key, query_version)?,
+            };
+            if let Some(prev_version) = prev_version {
+                batch.delete_cf_raw(
+                    V::HISTORICAL_COLUMN_FAMILY_NAME,
+                    encode_archival_key(key.as_ref(), prev_version),
+                );
+                keys_to_prune += 1;
+                // The watermark must cover the highest redirected query version.
+                last_pruned_version = last_pruned_version.max(Some(query_version));
+            }
+            prev_in_group = Some((key.as_ref(), *version));
+        }
+
+        // Clear the collected pruning entries with one range tombstone over
         // `[start-of-CF, pruning_cf_upper)`. `Vec::new()` sorts before all keys.
         batch.delete_range_cf_raw(V::PRUNING_COLUMN_FAMILY_NAME, Vec::new(), pruning_cf_upper);
 
@@ -958,13 +1007,13 @@ pub struct VersionedDbMetrics {
 pub struct PruningBatchOutput {
     /// Multi-CF batch of deletes and the metadata write.
     pub batch: SchemaBatch,
-    /// `true` if iteration stopped because `max_batch_size` was reached. Caller should
-    /// commit and re-invoke until this returns `false`.
+    /// `true` if `max_batch_size` was reached with pruning entries still remaining.
+    /// Caller should commit and re-invoke until this returns `false`.
     pub hit_size_limit: bool,
     /// The value recorded into [`VersionedTableMetadataKey::PrunedVersion`], or `None`
     /// when this batch deleted no historical rows.
     pub last_pruned_version: Option<u64>,
-    /// Number of pruning-CF entries the iterator visited. For metrics.
+    /// Number of pruning-CF entries collected (and fully processed) this pass. For metrics.
     pub keys_inspected: usize,
     /// Number of historical-CF delete operations placed in the batch. For metrics.
     pub keys_to_prune: usize,

--- a/src/versioned_db.rs
+++ b/src/versioned_db.rs
@@ -19,6 +19,7 @@ use crate::{
     iterator::{RawDbIter, ScanDirection},
     metrics::{SCHEMADB_BATCH_COMMIT_BYTES, SCHEMADB_DELETES, SCHEMADB_PUT_BYTES},
     schema::{ColumnFamilyName, KeyDecoder, KeyEncoder, ValueCodec},
+    schema_batch::RangeDeleteKey,
     BasicWeighter, CacheForSchema, CfDescriptorBuilder, CodecError, Schema, SchemaBatch, DB,
 };
 
@@ -214,7 +215,7 @@ impl<S: SchemaWithVersion, C: CacheForVersionedDB<S>> VersionedDB<S, C> {
     /// Triggers full compaction of the archival column families that pruning deletes from
     /// (historical + pruning), dropping the resulting tombstones and reclaiming disk.
     /// Intended to be called after committing a large pruning batch (e.g. a one-time
-    /// startup prune). Heavy — only sensible when there is no live read/write traffic.
+    /// startup prune). Heavy: only sensible when there is no live read/write traffic.
     ///
     /// The metadata CF and the live CF receive ~no deletes from pruning, so they are not
     /// compacted here.
@@ -577,7 +578,7 @@ where
     /// - deletes the historical-CF entry of the *previous* write of each collected K (so
     ///   the most recent write at or before `cutoff` survives, preserving the invariant
     ///   that every live key has at least one historical entry; see the doc on
-    ///   [`VersionedDB`]). These stay point deletes — they are scattered per-key and not
+    ///   [`VersionedDB`]). These stay point deletes; they are scattered per-key and not
     ///   safely range-able; their space is reclaimed by [`VersionedDB::trigger_compaction`].
     /// - writes [`VersionedTableMetadataKey::PrunedVersion`] = the greatest
     ///   `version - 1` for which this batch deleted a historical row, if any.
@@ -646,6 +647,15 @@ where
             }
         }
         let keys_inspected = collected.len();
+        if collected.is_empty() {
+            return Ok(PruningBatchOutput {
+                batch,
+                hit_size_limit,
+                last_pruned_version,
+                keys_inspected,
+                keys_to_prune,
+            });
+        }
 
         // The pruning CF is keyed `[version_be || key]` and every collected entry has
         // `version <= cutoff`, so the collected set is one contiguous prefix range that we
@@ -658,11 +668,7 @@ where
             let (last_version, last_key) = collected
                 .last()
                 .expect("hit_size_limit implies at least one collected entry");
-            let mut upper = encode_pruning_key(*last_version, last_key.as_ref());
-            // Appending 0x00 yields the smallest key strictly greater under bytewise
-            // ordering, making the bound inclusive of the last collected entry.
-            upper.push(0);
-            upper
+            encode_pruning_key(*last_version, last_key.as_ref()).range_delete_key_after()
         } else {
             cutoff.saturating_add(1).to_be_bytes().to_vec()
         };
@@ -674,7 +680,7 @@ where
 
         // Phase 3: walk each key's group `[V1 < V2 < ... < Vm]` and delete the historical
         // entry of each version's *previous* write, keeping the entry at `Vm` (the most
-        // recent write at or before `cutoff`) intact — preserves the "at least one entry
+        // recent write at or before `cutoff`) intact, preserving the "at least one entry
         // per live key" invariant; see the doc on [`VersionedDB`].
         //
         // For `Vi` with `i >= 2` the previous write is `V(i-1)`, known from the group
@@ -909,6 +915,12 @@ where
     }
 
     /// Returns the value of a key in the historical column family as of the given version.
+    ///
+    /// This is a raw archival lookup: it does not enforce
+    /// [`VersionedTableMetadataKey::PrunedVersion`]. After pruning, some survivor rows are
+    /// intentionally retained below the pruning watermark, so this method may return a
+    /// value for a version that strict historical readers should treat as pruned. Use
+    /// [`VersionedDeltaReader::get_historical_borrowed`] for watermark-aware reads.
     pub fn get_historical_value(
         &self,
         key_to_get: &impl KeyEncoder<V>,
@@ -926,7 +938,12 @@ where
         Ok(Some(value))
     }
 
-    /// Returns the value of a key in the historical column family as of the given version.
+    /// Returns the value of a pre-encoded key in the historical column family as of the
+    /// given version.
+    ///
+    /// This has the same raw archival semantics as [`Self::get_historical_value`]: it may
+    /// return retained survivor rows below [`VersionedTableMetadataKey::PrunedVersion`].
+    /// Use [`VersionedDeltaReader::get_historical_borrowed`] for watermark-aware reads.
     pub fn get_historical_value_raw(
         &self,
         pre_encoded_key_to_get: Vec<u8>,
@@ -945,6 +962,10 @@ where
     }
 
     /// Returns the latest version at which the given key was written.
+    ///
+    /// This is a raw archival lookup and does not enforce
+    /// [`VersionedTableMetadataKey::PrunedVersion`]. After pruning, it may report retained
+    /// survivor rows below the pruning watermark.
     pub fn get_version_for_key(
         &self,
         key_to_get: &impl KeyEncoder<V>,

--- a/src/versioned_db.rs
+++ b/src/versioned_db.rs
@@ -1543,3 +1543,47 @@ where
         self.versioned_db_cache.read().misses()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Locks the on-disk key layouts: the free `encode_*` helpers used on the pruning
+    /// path must stay byte-identical to `KeyWithVersionPrefixAndSuffix`, which defines
+    /// the canonical archival (`key || version_be`) and pruning (`version_be || key`)
+    /// layouts at write time. If either drifts, historical deletes and pruning-range
+    /// bounds silently target the wrong bytes.
+    #[test]
+    fn encode_helpers_match_key_with_version_layout() {
+        let cases: &[(&[u8], u64)] = &[
+            (b"k", 0),
+            (b"k", 1),
+            (b"k", u64::MAX),
+            (b"multi-byte-key", 42),
+            (&[0xff, 0x00, 0xff], u64::MAX),
+            (&[], 7),
+        ];
+
+        for &(key, version) in cases {
+            let mut key_with_version = KeyWithVersionPrefixAndSuffix::new(version);
+            key_with_version.set_key(key);
+
+            assert_eq!(
+                encode_archival_key(key, version),
+                key_with_version.archival_key(),
+                "archival layout mismatch for key={key:?} version={version}",
+            );
+            assert_eq!(
+                encode_pruning_key(version, key),
+                key_with_version.pruning_key(),
+                "pruning layout mismatch for key={key:?} version={version}",
+            );
+            // `live_key` must round-trip the original key out of the shared buffer.
+            assert_eq!(
+                key_with_version.live_key(),
+                key,
+                "live_key round-trip mismatch for key={key:?} version={version}",
+            );
+        }
+    }
+}

--- a/src/versioned_db.rs
+++ b/src/versioned_db.rs
@@ -210,6 +210,20 @@ impl<S: SchemaWithVersion, C: CacheForVersionedDB<S>> VersionedDB<S, C> {
     pub fn archival_db(&self) -> &DB {
         &self.archival_db
     }
+
+    /// Triggers full compaction of the archival column families that pruning deletes from
+    /// (historical + pruning), dropping the resulting tombstones and reclaiming disk.
+    /// Intended to be called after committing a large pruning batch (e.g. a one-time
+    /// startup prune). Heavy — only sensible when there is no live read/write traffic.
+    ///
+    /// The metadata CF and the live CF receive ~no deletes from pruning, so they are not
+    /// compacted here.
+    pub fn trigger_compaction(&self) -> anyhow::Result<()> {
+        self.archival_db
+            .compact_cf(S::HISTORICAL_COLUMN_FAMILY_NAME)?;
+        self.archival_db.compact_cf(S::PRUNING_COLUMN_FAMILY_NAME)?;
+        Ok(())
+    }
 }
 
 /// A key *prefixed* with a version number for easy iteration by version.
@@ -538,11 +552,16 @@ where
     /// the caller commits it via `archival_db.write_schemas(&output.batch)`.
     ///
     /// On commit, the batch:
-    /// - deletes pruning-CF entries `[V|K]` with `V <= cutoff` for every visited key,
-    /// - deletes the historical-CF entry of the *previous* write of each such K (so the
+    /// - clears pruning-CF entries `[V|K]` with `V <= cutoff` using a single range
+    ///   tombstone, bounded at the point where this pass stopped (see `max_batch_size`
+    ///   below). The bound never reaches past a pruning entry whose historical predecessor
+    ///   delete wasn't also emitted this pass — otherwise that historical row would be
+    ///   orphaned (its pruning index gone) and never reclaimed.
+    /// - deletes the historical-CF entry of the *previous* write of each visited K (so the
     ///   most recent write at or before `cutoff` survives, preserving the invariant
     ///   that every live key has at least one historical entry; see the doc on
-    ///   [`VersionedDB`]),
+    ///   [`VersionedDB`]). These stay point deletes — they are scattered per-key and not
+    ///   safely range-able; their space is reclaimed by [`VersionedDB::trigger_compaction`].
     /// - writes [`VersionedTableMetadataKey::PrunedVersion`] = the greatest
     ///   `version - 1` for which this batch deleted a historical row, if any.
     ///
@@ -581,13 +600,18 @@ where
             });
         };
 
+        // The pruning CF is keyed `[version_be || key]` and every entry we visit has
+        // `version <= cutoff`, so the visited set is one contiguous prefix range that we
+        // clear with a single range tombstone (after the loop) instead of one point delete
+        // per entry. `pruning_cf_upper` is the exclusive upper bound of that range: it
+        // starts at `first_version_to_keep` (covers everything `<= cutoff`) and, if we stop
+        // early on `max_batch_size`, is pulled back to the stopping point so we never drop a
+        // pruning entry whose historical predecessor delete wasn't also emitted this pass.
+        let mut pruning_cf_upper = cutoff.saturating_add(1).to_be_bytes().to_vec();
+
         for prunable in self.iter_pruning_keys_up_to_version(cutoff)? {
             keys_inspected += 1;
             let (version, key) = prunable.version_and_key();
-
-            let mut pruning_key_bytes = version.to_be_bytes().to_vec();
-            pruning_key_bytes.extend_from_slice(key.as_ref());
-            batch.delete_cf_raw(V::PRUNING_COLUMN_FAMILY_NAME, pruning_key_bytes);
 
             // Look up the previous version of this key and delete that historical entry,
             // keeping the entry at `version` intact. When `version == 0` or the key has no
@@ -605,9 +629,19 @@ where
 
             if max_batch_size.is_some_and(|m| keys_to_prune >= m) {
                 hit_size_limit = true;
+                // Stop the pruning-CF range at this entry (exclusive): everything strictly
+                // before it was fully processed this pass; this entry and any later ones
+                // keep their pruning index until a subsequent pass re-visits them.
+                let mut bound = version.to_be_bytes().to_vec();
+                bound.extend_from_slice(key.as_ref());
+                pruning_cf_upper = bound;
                 break;
             }
         }
+
+        // Collapse the per-entry pruning-CF deletes into one range tombstone over
+        // `[start-of-CF, pruning_cf_upper)`. `Vec::new()` sorts before all keys.
+        batch.delete_range_cf_raw(V::PRUNING_COLUMN_FAMILY_NAME, Vec::new(), pruning_cf_upper);
 
         if let Some(v) = last_pruned_version {
             batch.put_cf_raw(

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -208,6 +208,57 @@ fn test_two_schema_batches() {
 }
 
 #[test]
+fn test_merged_range_delete_preserves_later_put_inside_range() {
+    let db = TestDB::new();
+
+    let mut seed_batch = SchemaBatch::new();
+    for i in 1..5 {
+        seed_batch
+            .put::<TestSchema1>(&TestField(i), &TestField(i))
+            .unwrap();
+    }
+    db.write_schemas(&seed_batch).unwrap();
+
+    let mut db_batch1 = SchemaBatch::new();
+    db_batch1
+        .delete_range::<TestSchema1>(&TestField(1), &TestField(5))
+        .unwrap();
+
+    let mut db_batch2 = SchemaBatch::new();
+    db_batch2
+        .put::<TestSchema1>(&TestField(3), &TestField(30))
+        .unwrap();
+
+    db_batch1.merge(db_batch2);
+    db.write_schemas(&db_batch1).unwrap();
+
+    assert_eq!(
+        collect_values::<TestSchema1>(&db),
+        gen_expected_values(&[(3, 30)]),
+    );
+}
+
+#[test]
+fn test_merged_later_range_delete_removes_earlier_put_inside_range() {
+    let db = TestDB::new();
+
+    let mut db_batch1 = SchemaBatch::new();
+    db_batch1
+        .put::<TestSchema1>(&TestField(3), &TestField(30))
+        .unwrap();
+
+    let mut db_batch2 = SchemaBatch::new();
+    db_batch2
+        .delete_range::<TestSchema1>(&TestField(1), &TestField(5))
+        .unwrap();
+
+    db_batch1.merge(db_batch2);
+    db.write_schemas(&db_batch1).unwrap();
+
+    assert_eq!(collect_values::<TestSchema1>(&db), gen_expected_values(&[]),);
+}
+
+#[test]
 fn test_reopen() {
     let tmpdir = tempfile::tempdir().unwrap();
     {

--- a/tests/versioned_db_inner/mod.rs
+++ b/tests/versioned_db_inner/mod.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod delta_reader;
 mod iterator;
+mod pruning;
 
 use std::sync::Arc;
 

--- a/tests/versioned_db_inner/pruning.rs
+++ b/tests/versioned_db_inner/pruning.rs
@@ -106,6 +106,37 @@ fn basic_prune() {
     assert_eq!(historical(&delta_reader, b"k", 6).unwrap(), Some(6));
 }
 
+/// Smoke test for `VersionedDB::trigger_compaction`: after pruning + compaction the
+/// archival CFs are rewritten (tombstones dropped) and reads are unchanged.
+#[test]
+fn basic_prune_with_compaction() {
+    let (_dir, db) = open_versioned();
+    for v in 0..=9u64 {
+        put_at(&db, &[(b"k", v as u32)], v);
+    }
+    let out = db.collect_pruning_batch(3, None).unwrap();
+    commit_pruning_batch(&db, &out.batch);
+
+    db.trigger_compaction().unwrap();
+
+    for v in 0..=5u64 {
+        assert_eq!(
+            hist(&db, b"k", v),
+            None,
+            "k @ v={v} pruned (post-compaction)"
+        );
+    }
+    for v in 6..=9u64 {
+        assert_eq!(
+            hist(&db, b"k", v),
+            Some(v as u32),
+            "k @ v={v} survives (post-compaction)"
+        );
+    }
+    assert_eq!(db.get_pruned_version().unwrap(), Some(5));
+    assert_eq!(live(&db, b"k"), Some(9));
+}
+
 /// Mirrors the accessory Pruner A..G layout. cutoff = 9 - 3 = 6.
 #[test]
 fn multi_key_layout() {
@@ -317,20 +348,24 @@ fn max_batch_size_split() {
     ));
     assert_eq!(historical(&delta_reader, b"k", 3).unwrap(), Some(3));
 
-    // After commit: pruning entries [0..=3|k] gone, historical k|0,1,2 gone.
-    // Remaining pruning entries ≤ cutoff: [4|k], [5|k], [6|k]. Each produces one historical delete.
+    // After commit: pruning entries [0..=2|k] gone, historical k|0,1,2 gone. The break
+    // entry [3|k] lingers — the range tombstone stops exclusively at it.
+    // Remaining pruning entries ≤ cutoff: [3|k], [4|k], [5|k], [6|k]. [3|k] is re-inspected
+    // (its predecessor is already gone, so it yields no historical delete); [4|k], [5|k],
+    // [6|k] each produce one historical delete.
     let out2 = db.collect_pruning_batch(3, Some(3)).unwrap();
     assert!(out2.hit_size_limit);
     assert_eq!(out2.last_pruned_version, Some(5));
     assert_eq!(out2.keys_to_prune, 3);
-    assert_eq!(out2.keys_inspected, 3);
+    assert_eq!(out2.keys_inspected, 4); // re-inspects [3|k], then [4|k], [5|k], [6|k]
     commit_pruning_batch(&db, &out2.batch);
 
-    // No remaining pruning entries ≤ cutoff.
+    // Only the lingering [6|k] remains ≤ cutoff; out3 re-inspects it (no historical delete,
+    // its predecessor is gone) and the range tombstone retires it.
     let out3 = db.collect_pruning_batch(3, Some(3)).unwrap();
     assert!(!out3.hit_size_limit);
     assert_eq!(out3.keys_to_prune, 0);
-    assert_eq!(out3.keys_inspected, 0);
+    assert_eq!(out3.keys_inspected, 1); // re-inspects the lingering [6|k]
     assert_eq!(out3.last_pruned_version, None);
     commit_pruning_batch(&db, &out3.batch);
 
@@ -342,6 +377,92 @@ fn max_batch_size_split() {
         assert_eq!(hist(&db, b"k", v), Some(v as u32));
     }
     assert_eq!(db.get_pruned_version().unwrap(), Some(5));
+}
+
+/// Draining with a small `max_batch_size` must converge to the exact same final state as a
+/// single uncapped prune, and must fully clear the pruning index — guarding against an
+/// off-by-one in the range bound (a stranded pruning entry) or an over-eager bound (an
+/// orphaned historical row).
+#[test]
+fn capped_prune_converges_to_uncapped() {
+    let workload = |db: &V| {
+        for v in 0..=9u64 {
+            // `k` written every version; `m` only on even versions.
+            if v % 2 == 0 {
+                put_at(db, &[(b"k", v as u32), (b"m", v as u32)], v);
+            } else {
+                put_at(db, &[(b"k", v as u32)], v);
+            }
+        }
+    };
+
+    let (_dir_a, uncapped) = open_versioned();
+    workload(&uncapped);
+    let out = uncapped.collect_pruning_batch(3, None).unwrap();
+    assert!(!out.hit_size_limit);
+    commit_pruning_batch(&uncapped, &out.batch);
+
+    let (_dir_b, capped) = open_versioned();
+    workload(&capped);
+    loop {
+        let out = capped.collect_pruning_batch(3, Some(2)).unwrap();
+        commit_pruning_batch(&capped, &out.batch);
+        if !out.hit_size_limit {
+            break;
+        }
+    }
+
+    // cutoff = 9 - 3 = 6. Both strategies must drain every pruning entry ≤ cutoff.
+    assert_eq!(
+        uncapped.iter_pruning_keys_up_to_version(6).unwrap().count(),
+        0
+    );
+    assert_eq!(
+        capped.iter_pruning_keys_up_to_version(6).unwrap().count(),
+        0
+    );
+
+    // Final historical + live state must be identical between the two strategies.
+    for v in 0..=9u64 {
+        assert_eq!(
+            hist(&capped, b"k", v),
+            hist(&uncapped, b"k", v),
+            "k @ v={v}"
+        );
+        assert_eq!(
+            hist(&capped, b"m", v),
+            hist(&uncapped, b"m", v),
+            "m @ v={v}"
+        );
+    }
+    assert_eq!(live(&capped, b"k"), live(&uncapped, b"k"));
+    assert_eq!(live(&capped, b"m"), live(&uncapped, b"m"));
+    assert_eq!(
+        capped.get_pruned_version().unwrap(),
+        uncapped.get_pruned_version().unwrap()
+    );
+}
+
+/// Locks the exclusive range bound: after a capped pass that breaks on `[3|k]`, that break
+/// entry's pruning index must still be present (it is retired on a later pass). The old
+/// per-key point-delete approach would have left `[4, 5, 6]` here instead.
+#[test]
+fn capped_prune_leaves_break_entry_in_pruning_index_one_pass() {
+    let (_dir, db) = open_versioned();
+    for v in 0..=9u64 {
+        put_at(&db, &[(b"k", v as u32)], v);
+    }
+    let out1 = db.collect_pruning_batch(3, Some(3)).unwrap();
+    assert!(out1.hit_size_limit);
+    assert_eq!(out1.keys_inspected, 4); // visited V=0,1,2,3 — unchanged from point-delete
+    commit_pruning_batch(&db, &out1.batch);
+
+    let remaining: Vec<u64> = db
+        .iter_pruning_keys_up_to_version(6)
+        .unwrap()
+        .map(|p| p.version_and_key().0)
+        .collect();
+    assert_eq!(remaining, vec![3, 4, 5, 6]);
 }
 
 #[test]

--- a/tests/versioned_db_inner/pruning.rs
+++ b/tests/versioned_db_inner/pruning.rs
@@ -106,6 +106,37 @@ fn basic_prune() {
     assert_eq!(historical(&delta_reader, b"k", 6).unwrap(), Some(6));
 }
 
+#[test]
+fn direct_historical_lookup_can_return_survivor_below_pruned_watermark() {
+    let (_dir, db) = open_versioned();
+    for v in 0..=9u64 {
+        put_at(&db, &[(b"advancer", v as u32)], v);
+        if v == 0 || v >= 7 {
+            put_at(&db, &[(b"survivor", v as u32)], v);
+        }
+    }
+
+    let out = db.collect_pruning_batch(3, None).unwrap();
+    assert_eq!(out.last_pruned_version, Some(5));
+    commit_pruning_batch(&db, &out.batch);
+    assert_eq!(db.get_pruned_version().unwrap(), Some(5));
+
+    assert_eq!(hist(&db, b"survivor", 5), Some(0));
+
+    let delta_reader = VersionedDeltaReader::<LiveKeys, VersionedDbCache<LiveKeys>>::new(
+        db.clone(),
+        Some(9),
+        vec![],
+    );
+    assert!(matches!(
+        historical(&delta_reader, b"survivor", 5),
+        Err(HistoricalValueError::PrunedVersion {
+            requested_version: 5,
+            oldest_available_version: Some(6),
+        })
+    ));
+}
+
 /// Smoke test for `VersionedDB::trigger_compaction`: after pruning + compaction the
 /// archival CFs are rewritten (tombstones dropped) and reads are unchanged.
 #[test]
@@ -169,7 +200,7 @@ fn multi_key_layout() {
     type HistAt = (u64, Option<u32>);
     type HistCase<'a> = (&'a [u8], &'a [HistAt]);
     let cases: &[HistCase] = &[
-        // A written at [6,7,8,9]; V=6 is first → no historical delete → all 4 entries survive.
+        // A written at [6,7,8,9]; V=6 is first, so no historical delete; all 4 entries survive.
         (
             b"A",
             &[
@@ -185,7 +216,7 @@ fn multi_key_layout() {
                 (9, Some(9)),
             ],
         ),
-        // B written at [7,8,9]; no pruning entries ≤ 6.
+        // B written at [7,8,9]; no pruning entries <= 6.
         (
             b"B",
             &[
@@ -265,7 +296,7 @@ fn multi_key_layout() {
                 (9, Some(3)),
             ],
         ),
-        // G written at [0,7,8,9]; V=0 is first → kept. Survivors: G@0,7,8,9.
+        // G written at [0,7,8,9]; V=0 is first and is kept. Survivors: G@0,7,8,9.
         (
             b"G",
             &[
@@ -324,7 +355,7 @@ fn max_batch_size_split() {
         put_at(&db, &[(b"k", v as u32)], v);
     }
 
-    // 7 pruning entries ≤ cutoff=6 (V=0..=6). With max_batch_size=3, each pass collects
+    // 7 pruning entries <= cutoff=6 (V=0..=6). With max_batch_size=3, each pass collects
     // (and fully retires) exactly 3 entries.
     // Pass 1 collects [0|k], [1|k], [2|k]: V=0 is the group's oldest with nothing before
     // it (no delete); V=1 and V=2 delete their in-group predecessors k|0 and k|1.
@@ -351,7 +382,7 @@ fn max_batch_size_split() {
     assert_eq!(historical(&delta_reader, b"k", 2).unwrap(), Some(2));
 
     // After commit: pruning entries [0..=2|k] gone, historical k|0,k|1 gone. Remaining
-    // pruning entries ≤ cutoff: [3|k], [4|k], [5|k], [6|k].
+    // pruning entries <= cutoff: [3|k], [4|k], [5|k], [6|k].
     // Pass 2 collects [3|k], [4|k], [5|k]: V=3 is now its group's oldest, so it looks up
     // its predecessor (the survivor k|2) and deletes it; V=4 and V=5 delete k|3 and k|4.
     let out2 = db.collect_pruning_batch(3, Some(3)).unwrap();
@@ -361,7 +392,7 @@ fn max_batch_size_split() {
     assert_eq!(out2.keys_inspected, 3); // V=3,4,5
     commit_pruning_batch(&db, &out2.batch);
 
-    // Only [6|k] remains ≤ cutoff; the final pass deletes its predecessor (the survivor
+    // Only [6|k] remains <= cutoff; the final pass deletes its predecessor (the survivor
     // k|5) and drains the iterator, so the cap is not hit.
     let out3 = db.collect_pruning_batch(3, Some(3)).unwrap();
     assert!(!out3.hit_size_limit);
@@ -381,7 +412,7 @@ fn max_batch_size_split() {
 }
 
 /// Draining with a small `max_batch_size` must converge to the exact same final state as a
-/// single uncapped prune, and must fully clear the pruning index — guarding against an
+/// single uncapped prune, and must fully clear the pruning index, guarding against an
 /// off-by-one in the range bound (a stranded pruning entry) or an over-eager bound (an
 /// orphaned historical row).
 #[test]
@@ -413,7 +444,7 @@ fn capped_prune_converges_to_uncapped() {
         }
     }
 
-    // cutoff = 9 - 3 = 6. Both strategies must drain every pruning entry ≤ cutoff.
+    // cutoff = 9 - 3 = 6. Both strategies must drain every pruning entry <= cutoff.
     assert_eq!(
         uncapped.iter_pruning_keys_up_to_version(6).unwrap().count(),
         0
@@ -445,7 +476,7 @@ fn capped_prune_converges_to_uncapped() {
 }
 
 /// Locks the inclusive range bound: a capped pass fully retires exactly the entries it
-/// collected — `[0|k]`, `[1|k]`, `[2|k]` are cleared from the pruning index (every one had
+/// collected: `[0|k]`, `[1|k]`, `[2|k]` are cleared from the pruning index (every one had
 /// its predecessor handling emitted in the same batch) while the uncollected `[3..=6|k]`
 /// remain for later passes. An over-eager bound would orphan a historical row; a stranded
 /// collected entry would waste a re-inspection.
@@ -539,7 +570,7 @@ fn max_batch_size_zero_errors() {
 
 #[test]
 fn cutoff_underflow_returns_empty() {
-    // last_committed < keep_versions → checked_sub underflows → empty batch.
+    // last_committed < keep_versions means checked_sub underflows, yielding an empty batch.
     let (_dir, db) = open_versioned();
     put_at(&db, &[(b"k", 0)], 0);
     put_at(&db, &[(b"k", 1)], 1);

--- a/tests/versioned_db_inner/pruning.rs
+++ b/tests/versioned_db_inner/pruning.rs
@@ -493,6 +493,21 @@ fn keep_versions_zero_errors() {
 }
 
 #[test]
+fn max_batch_size_zero_errors() {
+    let (_dir, db) = open_versioned();
+    for v in 0..=9u64 {
+        put_at(&db, &[(b"k", v as u32)], v);
+    }
+
+    let err = db.collect_pruning_batch(3, Some(0)).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("max_batch_size must be >= 1 when set"),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
 fn cutoff_underflow_returns_empty() {
     // last_committed < keep_versions → checked_sub underflows → empty batch.
     let (_dir, db) = open_versioned();

--- a/tests/versioned_db_inner/pruning.rs
+++ b/tests/versioned_db_inner/pruning.rs
@@ -324,15 +324,17 @@ fn max_batch_size_split() {
         put_at(&db, &[(b"k", v as u32)], v);
     }
 
-    // 7 pruning entries ≤ cutoff=6 (V=0..=6); V=0 produces no historical delete.
-    // With max_batch_size=3, the first run breaks after the 3rd historical delete (V=3).
+    // 7 pruning entries ≤ cutoff=6 (V=0..=6). With max_batch_size=3, each pass collects
+    // (and fully retires) exactly 3 entries.
+    // Pass 1 collects [0|k], [1|k], [2|k]: V=0 is the group's oldest with nothing before
+    // it (no delete); V=1 and V=2 delete their in-group predecessors k|0 and k|1.
     let out1 = db.collect_pruning_batch(3, Some(3)).unwrap();
     assert!(out1.hit_size_limit);
-    assert_eq!(out1.last_pruned_version, Some(2));
-    assert_eq!(out1.keys_to_prune, 3);
-    assert_eq!(out1.keys_inspected, 4); // V=0,1,2,3
+    assert_eq!(out1.last_pruned_version, Some(1));
+    assert_eq!(out1.keys_to_prune, 2);
+    assert_eq!(out1.keys_inspected, 3); // V=0,1,2
     commit_pruning_batch(&db, &out1.batch);
-    assert_eq!(db.get_pruned_version().unwrap(), Some(2));
+    assert_eq!(db.get_pruned_version().unwrap(), Some(1));
 
     let delta_reader = VersionedDeltaReader::<LiveKeys, VersionedDbCache<LiveKeys>>::new(
         db.clone(),
@@ -340,33 +342,32 @@ fn max_batch_size_split() {
         vec![],
     );
     assert!(matches!(
-        historical(&delta_reader, b"k", 2),
+        historical(&delta_reader, b"k", 1),
         Err(HistoricalValueError::PrunedVersion {
-            requested_version: 2,
-            oldest_available_version: Some(3),
+            requested_version: 1,
+            oldest_available_version: Some(2),
         })
     ));
-    assert_eq!(historical(&delta_reader, b"k", 3).unwrap(), Some(3));
+    assert_eq!(historical(&delta_reader, b"k", 2).unwrap(), Some(2));
 
-    // After commit: pruning entries [0..=2|k] gone, historical k|0,1,2 gone. The break
-    // entry [3|k] lingers — the range tombstone stops exclusively at it.
-    // Remaining pruning entries ≤ cutoff: [3|k], [4|k], [5|k], [6|k]. [3|k] is re-inspected
-    // (its predecessor is already gone, so it yields no historical delete); [4|k], [5|k],
-    // [6|k] each produce one historical delete.
+    // After commit: pruning entries [0..=2|k] gone, historical k|0,k|1 gone. Remaining
+    // pruning entries ≤ cutoff: [3|k], [4|k], [5|k], [6|k].
+    // Pass 2 collects [3|k], [4|k], [5|k]: V=3 is now its group's oldest, so it looks up
+    // its predecessor (the survivor k|2) and deletes it; V=4 and V=5 delete k|3 and k|4.
     let out2 = db.collect_pruning_batch(3, Some(3)).unwrap();
     assert!(out2.hit_size_limit);
-    assert_eq!(out2.last_pruned_version, Some(5));
+    assert_eq!(out2.last_pruned_version, Some(4));
     assert_eq!(out2.keys_to_prune, 3);
-    assert_eq!(out2.keys_inspected, 4); // re-inspects [3|k], then [4|k], [5|k], [6|k]
+    assert_eq!(out2.keys_inspected, 3); // V=3,4,5
     commit_pruning_batch(&db, &out2.batch);
 
-    // Only the lingering [6|k] remains ≤ cutoff; out3 re-inspects it (no historical delete,
-    // its predecessor is gone) and the range tombstone retires it.
+    // Only [6|k] remains ≤ cutoff; the final pass deletes its predecessor (the survivor
+    // k|5) and drains the iterator, so the cap is not hit.
     let out3 = db.collect_pruning_batch(3, Some(3)).unwrap();
     assert!(!out3.hit_size_limit);
-    assert_eq!(out3.keys_to_prune, 0);
-    assert_eq!(out3.keys_inspected, 1); // re-inspects the lingering [6|k]
-    assert_eq!(out3.last_pruned_version, None);
+    assert_eq!(out3.keys_to_prune, 1);
+    assert_eq!(out3.keys_inspected, 1);
+    assert_eq!(out3.last_pruned_version, Some(5));
     commit_pruning_batch(&db, &out3.batch);
 
     // Final state should match the basic_prune outcome.
@@ -443,18 +444,20 @@ fn capped_prune_converges_to_uncapped() {
     );
 }
 
-/// Locks the exclusive range bound: after a capped pass that breaks on `[3|k]`, that break
-/// entry's pruning index must still be present (it is retired on a later pass). The old
-/// per-key point-delete approach would have left `[4, 5, 6]` here instead.
+/// Locks the inclusive range bound: a capped pass fully retires exactly the entries it
+/// collected — `[0|k]`, `[1|k]`, `[2|k]` are cleared from the pruning index (every one had
+/// its predecessor handling emitted in the same batch) while the uncollected `[3..=6|k]`
+/// remain for later passes. An over-eager bound would orphan a historical row; a stranded
+/// collected entry would waste a re-inspection.
 #[test]
-fn capped_prune_leaves_break_entry_in_pruning_index_one_pass() {
+fn capped_prune_clears_exactly_the_collected_prefix() {
     let (_dir, db) = open_versioned();
     for v in 0..=9u64 {
         put_at(&db, &[(b"k", v as u32)], v);
     }
     let out1 = db.collect_pruning_batch(3, Some(3)).unwrap();
     assert!(out1.hit_size_limit);
-    assert_eq!(out1.keys_inspected, 4); // visited V=0,1,2,3 — unchanged from point-delete
+    assert_eq!(out1.keys_inspected, 3); // collected V=0,1,2
     commit_pruning_batch(&db, &out1.batch);
 
     let remaining: Vec<u64> = db
@@ -557,10 +560,12 @@ fn partial_pruned_version_persists_across_reopen() {
         for v in 0..=9u64 {
             put_at(&versioned_db, &[(b"k", v as u32)], v);
         }
+        // The capped pass collects [0|k], [1|k], [2|k]; V=1 and V=2 delete k|0 and k|1,
+        // so the watermark lands on V=2's query version (1).
         let out = versioned_db.collect_pruning_batch(3, Some(3)).unwrap();
-        assert_eq!(out.last_pruned_version, Some(2));
+        assert_eq!(out.last_pruned_version, Some(1));
         commit_pruning_batch(&versioned_db, &out.batch);
-        assert_eq!(versioned_db.get_pruned_version().unwrap(), Some(2));
+        assert_eq!(versioned_db.get_pruned_version().unwrap(), Some(1));
 
         let delta_reader = VersionedDeltaReader::<LiveKeys, VersionedDbCache<LiveKeys>>::new(
             versioned_db.clone(),
@@ -568,13 +573,13 @@ fn partial_pruned_version_persists_across_reopen() {
             vec![],
         );
         assert!(matches!(
-            historical(&delta_reader, b"k", 2),
+            historical(&delta_reader, b"k", 1),
             Err(HistoricalValueError::PrunedVersion {
-                requested_version: 2,
-                oldest_available_version: Some(3),
+                requested_version: 1,
+                oldest_available_version: Some(2),
             })
         ));
-        assert_eq!(historical(&delta_reader, b"k", 3).unwrap(), Some(3));
+        assert_eq!(historical(&delta_reader, b"k", 2).unwrap(), Some(2));
 
         tmpdir
     };
@@ -583,7 +588,7 @@ fn partial_pruned_version_persists_across_reopen() {
     let db = Arc::new(test_db.db);
     let cache = VersionedDbCache::new(10_000);
     let reopened = Arc::new(V::from_dbs(db.clone(), db, cache).unwrap());
-    assert_eq!(reopened.get_pruned_version().unwrap(), Some(2));
+    assert_eq!(reopened.get_pruned_version().unwrap(), Some(1));
 
     let delta_reader = VersionedDeltaReader::<LiveKeys, VersionedDbCache<LiveKeys>>::new(
         reopened,
@@ -591,13 +596,13 @@ fn partial_pruned_version_persists_across_reopen() {
         vec![],
     );
     assert!(matches!(
-        historical(&delta_reader, b"k", 2),
+        historical(&delta_reader, b"k", 1),
         Err(HistoricalValueError::PrunedVersion {
-            requested_version: 2,
-            oldest_available_version: Some(3),
+            requested_version: 1,
+            oldest_available_version: Some(2),
         })
     ));
-    assert_eq!(historical(&delta_reader, b"k", 3).unwrap(), Some(3));
+    assert_eq!(historical(&delta_reader, b"k", 2).unwrap(), Some(2));
 }
 
 #[test]

--- a/tests/versioned_db_inner/pruning.rs
+++ b/tests/versioned_db_inner/pruning.rs
@@ -477,10 +477,37 @@ fn empty_db() {
     assert_eq!(out.last_pruned_version, None);
     assert_eq!(out.keys_inspected, 0);
     assert_eq!(out.keys_to_prune, 0);
+    assert!(out.batch.is_empty());
 
     // Committing the empty batch is harmless and doesn't introduce a pruned version.
     commit_pruning_batch(&db, &out.batch);
     assert_eq!(db.get_pruned_version().unwrap(), None);
+}
+
+#[test]
+fn repeated_prune_after_cutoff_drained_returns_empty_batch() {
+    let (_dir, db) = open_versioned();
+    for v in 0..=9u64 {
+        put_at(&db, &[(b"k", v as u32)], v);
+    }
+
+    let out1 = db.collect_pruning_batch(3, None).unwrap();
+    commit_pruning_batch(&db, &out1.batch);
+    assert_eq!(
+        db.iter_pruning_keys_up_to_version(6).unwrap().count(),
+        0,
+        "first prune should drain all pruning entries up to cutoff",
+    );
+
+    let out2 = db.collect_pruning_batch(3, None).unwrap();
+    assert!(!out2.hit_size_limit);
+    assert_eq!(out2.last_pruned_version, None);
+    assert_eq!(out2.keys_inspected, 0);
+    assert_eq!(out2.keys_to_prune, 0);
+    assert!(out2.batch.is_empty());
+
+    commit_pruning_batch(&db, &out2.batch);
+    assert_eq!(db.get_pruned_version().unwrap(), Some(5));
 }
 
 #[test]
@@ -522,6 +549,7 @@ fn cutoff_underflow_returns_empty() {
     assert_eq!(out.last_pruned_version, None);
     assert_eq!(out.keys_inspected, 0);
     assert_eq!(out.keys_to_prune, 0);
+    assert!(out.batch.is_empty());
 }
 
 #[test]

--- a/tests/versioned_db_inner/pruning.rs
+++ b/tests/versioned_db_inner/pruning.rs
@@ -1,0 +1,516 @@
+use std::sync::Arc;
+
+use rockbound::versioned_db::{
+    HistoricalValueError, VersionedDB, VersionedDeltaReader, VersionedSchemaBatch,
+};
+use rockbound::SchemaBatch;
+use tempfile::TempDir;
+
+use super::{commit_batch, LiveKeys, TestDB, TestField, TestKey, VersionedDbCache};
+
+type V = VersionedDB<LiveKeys, VersionedDbCache<LiveKeys>>;
+
+fn open_versioned() -> (TempDir, Arc<V>) {
+    let TestDB { tmpdir, db } = TestDB::new();
+    let db = Arc::new(db);
+    let cache = VersionedDbCache::new(10_000);
+    let versioned_db = Arc::new(V::from_dbs(db.clone(), db, cache).unwrap());
+    (tmpdir, versioned_db)
+}
+
+fn put_at(versioned_db: &V, keys: &[(&[u8], u32)], version: u64) {
+    let mut batch = VersionedSchemaBatch::<LiveKeys>::default();
+    for (k, v) in keys {
+        batch.put_versioned(TestKey::from(k.to_vec()), TestField::new(*v));
+    }
+    commit_batch(versioned_db, &batch, version);
+}
+
+fn delete_at(versioned_db: &V, keys: &[&[u8]], version: u64) {
+    let mut batch = VersionedSchemaBatch::<LiveKeys>::default();
+    for k in keys {
+        batch.delete_versioned(TestKey::from(k.to_vec()));
+    }
+    commit_batch(versioned_db, &batch, version);
+}
+
+fn commit_pruning_batch(versioned_db: &V, batch: &SchemaBatch) {
+    versioned_db.archival_db().write_schemas(batch).unwrap();
+}
+
+fn hist(versioned_db: &V, key: &[u8], version: u64) -> Option<u32> {
+    versioned_db
+        .get_historical_value(&TestKey::from(key.to_vec()), version)
+        .unwrap()
+        .map(|f| f.value())
+}
+
+fn live(versioned_db: &V, key: &[u8]) -> Option<u32> {
+    versioned_db
+        .get_live_value(&TestKey::from(key.to_vec()))
+        .unwrap()
+        .map(|f| f.value())
+}
+
+fn historical(
+    delta_reader: &VersionedDeltaReader<LiveKeys, VersionedDbCache<LiveKeys>>,
+    key: &[u8],
+    version: u64,
+) -> Result<Option<u32>, HistoricalValueError> {
+    delta_reader
+        .get_historical_borrowed(&TestKey::from(key.to_vec()), version)
+        .map(|value| value.map(|field| field.value()))
+}
+
+#[test]
+fn basic_prune() {
+    let (_dir, db) = open_versioned();
+    for v in 0..=9u64 {
+        put_at(&db, &[(b"k", v as u32)], v);
+    }
+
+    let out = db.collect_pruning_batch(3, None).unwrap();
+    assert!(!out.hit_size_limit);
+    assert_eq!(out.last_pruned_version, Some(5));
+    // V=0 has no prev write, so no historical delete; V=1..=6 each produce one historical delete.
+    assert_eq!(out.keys_to_prune, 6);
+    assert_eq!(out.keys_inspected, 7);
+
+    commit_pruning_batch(&db, &out.batch);
+
+    for v in 0..=5u64 {
+        assert_eq!(hist(&db, b"k", v), None, "k @ v={v} should be pruned");
+    }
+    for v in 6..=9u64 {
+        assert_eq!(
+            hist(&db, b"k", v),
+            Some(v as u32),
+            "k @ v={v} should survive"
+        );
+    }
+    assert_eq!(db.get_pruned_version().unwrap(), Some(5));
+    assert_eq!(live(&db, b"k"), Some(9));
+
+    let delta_reader = VersionedDeltaReader::<LiveKeys, VersionedDbCache<LiveKeys>>::new(
+        db.clone(),
+        Some(9),
+        vec![],
+    );
+    assert!(matches!(
+        historical(&delta_reader, b"k", 5),
+        Err(HistoricalValueError::PrunedVersion {
+            requested_version: 5,
+            oldest_available_version: Some(6),
+        })
+    ));
+    assert_eq!(historical(&delta_reader, b"k", 6).unwrap(), Some(6));
+}
+
+/// Mirrors the accessory Pruner A..G layout. cutoff = 9 - 3 = 6.
+#[test]
+fn multi_key_layout() {
+    let (_dir, db) = open_versioned();
+
+    put_at(
+        &db,
+        &[(b"C", 0), (b"D", 0), (b"E", 0), (b"F", 0), (b"G", 0)],
+        0,
+    );
+    put_at(&db, &[(b"C", 1), (b"E", 1), (b"F", 1)], 1);
+    put_at(&db, &[(b"C", 2), (b"E", 2), (b"F", 2)], 2);
+    put_at(&db, &[(b"C", 3), (b"D", 3), (b"F", 3)], 3);
+    put_at(&db, &[(b"C", 4)], 4);
+    put_at(&db, &[(b"C", 5)], 5);
+    put_at(&db, &[(b"A", 6), (b"C", 6), (b"D", 6)], 6);
+    put_at(&db, &[(b"A", 7), (b"B", 7), (b"C", 7), (b"G", 7)], 7);
+    put_at(&db, &[(b"A", 8), (b"B", 8), (b"C", 8), (b"G", 8)], 8);
+    put_at(
+        &db,
+        &[(b"A", 9), (b"B", 9), (b"C", 9), (b"D", 9), (b"G", 9)],
+        9,
+    );
+
+    let out = db.collect_pruning_batch(3, None).unwrap();
+    assert!(!out.hit_size_limit);
+    assert_eq!(out.last_pruned_version, Some(5));
+    commit_pruning_batch(&db, &out.batch);
+
+    type HistAt = (u64, Option<u32>);
+    type HistCase<'a> = (&'a [u8], &'a [HistAt]);
+    let cases: &[HistCase] = &[
+        // A written at [6,7,8,9]; V=6 is first → no historical delete → all 4 entries survive.
+        (
+            b"A",
+            &[
+                (0, None),
+                (1, None),
+                (2, None),
+                (3, None),
+                (4, None),
+                (5, None),
+                (6, Some(6)),
+                (7, Some(7)),
+                (8, Some(8)),
+                (9, Some(9)),
+            ],
+        ),
+        // B written at [7,8,9]; no pruning entries ≤ 6.
+        (
+            b"B",
+            &[
+                (0, None),
+                (1, None),
+                (2, None),
+                (3, None),
+                (4, None),
+                (5, None),
+                (6, None),
+                (7, Some(7)),
+                (8, Some(8)),
+                (9, Some(9)),
+            ],
+        ),
+        // C written at [0..=9]; V=1..=6 each delete the prev. Survivors: C@6,7,8,9.
+        (
+            b"C",
+            &[
+                (0, None),
+                (1, None),
+                (2, None),
+                (3, None),
+                (4, None),
+                (5, None),
+                (6, Some(6)),
+                (7, Some(7)),
+                (8, Some(8)),
+                (9, Some(9)),
+            ],
+        ),
+        // D written at [0,3,6,9]; survivors: D@6, D@9.
+        (
+            b"D",
+            &[
+                (0, None),
+                (1, None),
+                (2, None),
+                (3, None),
+                (4, None),
+                (5, None),
+                (6, Some(6)),
+                (7, Some(6)),
+                (8, Some(6)),
+                (9, Some(9)),
+            ],
+        ),
+        // E written at [0,1,2]; survivor: E@2.
+        (
+            b"E",
+            &[
+                (0, None),
+                (1, None),
+                (2, Some(2)),
+                (3, Some(2)),
+                (4, Some(2)),
+                (5, Some(2)),
+                (6, Some(2)),
+                (7, Some(2)),
+                (8, Some(2)),
+                (9, Some(2)),
+            ],
+        ),
+        // F written at [0,1,2,3]; survivor: F@3.
+        (
+            b"F",
+            &[
+                (0, None),
+                (1, None),
+                (2, None),
+                (3, Some(3)),
+                (4, Some(3)),
+                (5, Some(3)),
+                (6, Some(3)),
+                (7, Some(3)),
+                (8, Some(3)),
+                (9, Some(3)),
+            ],
+        ),
+        // G written at [0,7,8,9]; V=0 is first → kept. Survivors: G@0,7,8,9.
+        (
+            b"G",
+            &[
+                (0, Some(0)),
+                (1, Some(0)),
+                (2, Some(0)),
+                (3, Some(0)),
+                (4, Some(0)),
+                (5, Some(0)),
+                (6, Some(0)),
+                (7, Some(7)),
+                (8, Some(8)),
+                (9, Some(9)),
+            ],
+        ),
+    ];
+
+    for (key, queries) in cases {
+        for (qv, expected) in *queries {
+            assert_eq!(
+                hist(&db, key, *qv),
+                *expected,
+                "historical({}, {}) mismatch",
+                std::str::from_utf8(key).unwrap(),
+                qv,
+            );
+        }
+    }
+
+    // Live values are unaffected by pruning.
+    for (key, latest) in [
+        (&b"A"[..], 9u32),
+        (b"B", 9),
+        (b"C", 9),
+        (b"D", 9),
+        // E, F have no writes after pruning boundary but live still reflects their last write
+        (b"E", 2),
+        (b"F", 3),
+        (b"G", 9),
+    ] {
+        assert_eq!(
+            live(&db, key),
+            Some(latest),
+            "live({}) mismatch",
+            std::str::from_utf8(key).unwrap()
+        );
+    }
+
+    assert_eq!(db.get_pruned_version().unwrap(), Some(5));
+}
+
+#[test]
+fn max_batch_size_split() {
+    let (_dir, db) = open_versioned();
+    for v in 0..=9u64 {
+        put_at(&db, &[(b"k", v as u32)], v);
+    }
+
+    // 7 pruning entries ≤ cutoff=6 (V=0..=6); V=0 produces no historical delete.
+    // With max_batch_size=3, the first run breaks after the 3rd historical delete (V=3).
+    let out1 = db.collect_pruning_batch(3, Some(3)).unwrap();
+    assert!(out1.hit_size_limit);
+    assert_eq!(out1.last_pruned_version, Some(2));
+    assert_eq!(out1.keys_to_prune, 3);
+    assert_eq!(out1.keys_inspected, 4); // V=0,1,2,3
+    commit_pruning_batch(&db, &out1.batch);
+    assert_eq!(db.get_pruned_version().unwrap(), Some(2));
+
+    let delta_reader = VersionedDeltaReader::<LiveKeys, VersionedDbCache<LiveKeys>>::new(
+        db.clone(),
+        Some(9),
+        vec![],
+    );
+    assert!(matches!(
+        historical(&delta_reader, b"k", 2),
+        Err(HistoricalValueError::PrunedVersion {
+            requested_version: 2,
+            oldest_available_version: Some(3),
+        })
+    ));
+    assert_eq!(historical(&delta_reader, b"k", 3).unwrap(), Some(3));
+
+    // After commit: pruning entries [0..=3|k] gone, historical k|0,1,2 gone.
+    // Remaining pruning entries ≤ cutoff: [4|k], [5|k], [6|k]. Each produces one historical delete.
+    let out2 = db.collect_pruning_batch(3, Some(3)).unwrap();
+    assert!(out2.hit_size_limit);
+    assert_eq!(out2.last_pruned_version, Some(5));
+    assert_eq!(out2.keys_to_prune, 3);
+    assert_eq!(out2.keys_inspected, 3);
+    commit_pruning_batch(&db, &out2.batch);
+
+    // No remaining pruning entries ≤ cutoff.
+    let out3 = db.collect_pruning_batch(3, Some(3)).unwrap();
+    assert!(!out3.hit_size_limit);
+    assert_eq!(out3.keys_to_prune, 0);
+    assert_eq!(out3.keys_inspected, 0);
+    assert_eq!(out3.last_pruned_version, None);
+    commit_pruning_batch(&db, &out3.batch);
+
+    // Final state should match the basic_prune outcome.
+    for v in 0..=5u64 {
+        assert_eq!(hist(&db, b"k", v), None);
+    }
+    for v in 6..=9u64 {
+        assert_eq!(hist(&db, b"k", v), Some(v as u32));
+    }
+    assert_eq!(db.get_pruned_version().unwrap(), Some(5));
+}
+
+#[test]
+fn empty_db() {
+    let (_dir, db) = open_versioned();
+
+    let out = db.collect_pruning_batch(3, None).unwrap();
+    assert!(!out.hit_size_limit);
+    assert_eq!(out.last_pruned_version, None);
+    assert_eq!(out.keys_inspected, 0);
+    assert_eq!(out.keys_to_prune, 0);
+
+    // Committing the empty batch is harmless and doesn't introduce a pruned version.
+    commit_pruning_batch(&db, &out.batch);
+    assert_eq!(db.get_pruned_version().unwrap(), None);
+}
+
+#[test]
+fn keep_versions_zero_errors() {
+    let (_dir, db) = open_versioned();
+    put_at(&db, &[(b"k", 0)], 0);
+
+    let err = db.collect_pruning_batch(0, None).unwrap_err();
+    assert!(
+        err.to_string().contains("keep_versions must be >= 1"),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
+fn cutoff_underflow_returns_empty() {
+    // last_committed < keep_versions → checked_sub underflows → empty batch.
+    let (_dir, db) = open_versioned();
+    put_at(&db, &[(b"k", 0)], 0);
+    put_at(&db, &[(b"k", 1)], 1);
+
+    let out = db.collect_pruning_batch(5, None).unwrap();
+    assert!(!out.hit_size_limit);
+    assert_eq!(out.last_pruned_version, None);
+    assert_eq!(out.keys_inspected, 0);
+    assert_eq!(out.keys_to_prune, 0);
+}
+
+#[test]
+fn pruned_version_persists_across_reopen() {
+    let dir = {
+        let TestDB { tmpdir, db } = TestDB::new();
+        let db = Arc::new(db);
+        let cache = VersionedDbCache::new(10_000);
+        let versioned_db = Arc::new(V::from_dbs(db.clone(), db, cache).unwrap());
+
+        for v in 0..=9u64 {
+            put_at(&versioned_db, &[(b"k", v as u32)], v);
+        }
+        let out = versioned_db.collect_pruning_batch(3, None).unwrap();
+        commit_pruning_batch(&versioned_db, &out.batch);
+        assert_eq!(versioned_db.get_pruned_version().unwrap(), Some(5));
+
+        tmpdir
+    };
+
+    let test_db = TestDB::from_tempdir(dir);
+    let db = Arc::new(test_db.db);
+    let cache = VersionedDbCache::new(10_000);
+    let reopened = V::from_dbs(db.clone(), db, cache).unwrap();
+    assert_eq!(reopened.get_pruned_version().unwrap(), Some(5));
+}
+
+#[test]
+fn partial_pruned_version_persists_across_reopen() {
+    let dir = {
+        let TestDB { tmpdir, db } = TestDB::new();
+        let db = Arc::new(db);
+        let cache = VersionedDbCache::new(10_000);
+        let versioned_db = Arc::new(V::from_dbs(db.clone(), db, cache).unwrap());
+
+        for v in 0..=9u64 {
+            put_at(&versioned_db, &[(b"k", v as u32)], v);
+        }
+        let out = versioned_db.collect_pruning_batch(3, Some(3)).unwrap();
+        assert_eq!(out.last_pruned_version, Some(2));
+        commit_pruning_batch(&versioned_db, &out.batch);
+        assert_eq!(versioned_db.get_pruned_version().unwrap(), Some(2));
+
+        let delta_reader = VersionedDeltaReader::<LiveKeys, VersionedDbCache<LiveKeys>>::new(
+            versioned_db.clone(),
+            Some(9),
+            vec![],
+        );
+        assert!(matches!(
+            historical(&delta_reader, b"k", 2),
+            Err(HistoricalValueError::PrunedVersion {
+                requested_version: 2,
+                oldest_available_version: Some(3),
+            })
+        ));
+        assert_eq!(historical(&delta_reader, b"k", 3).unwrap(), Some(3));
+
+        tmpdir
+    };
+
+    let test_db = TestDB::from_tempdir(dir);
+    let db = Arc::new(test_db.db);
+    let cache = VersionedDbCache::new(10_000);
+    let reopened = Arc::new(V::from_dbs(db.clone(), db, cache).unwrap());
+    assert_eq!(reopened.get_pruned_version().unwrap(), Some(2));
+
+    let delta_reader = VersionedDeltaReader::<LiveKeys, VersionedDbCache<LiveKeys>>::new(
+        reopened,
+        Some(9),
+        vec![],
+    );
+    assert!(matches!(
+        historical(&delta_reader, b"k", 2),
+        Err(HistoricalValueError::PrunedVersion {
+            requested_version: 2,
+            oldest_available_version: Some(3),
+        })
+    ));
+    assert_eq!(historical(&delta_reader, b"k", 3).unwrap(), Some(3));
+}
+
+#[test]
+fn no_historical_deletes_do_not_advance_pruned_version() {
+    let (_dir, db) = open_versioned();
+
+    for v in 0..=9u64 {
+        let key = format!("k{v}").into_bytes();
+        put_at(&db, &[(key.as_slice(), v as u32)], v);
+    }
+
+    let out = db.collect_pruning_batch(3, None).unwrap();
+    assert!(!out.hit_size_limit);
+    assert_eq!(out.last_pruned_version, None);
+    assert_eq!(out.keys_inspected, 7);
+    assert_eq!(out.keys_to_prune, 0);
+
+    commit_pruning_batch(&db, &out.batch);
+    assert_eq!(db.get_pruned_version().unwrap(), None);
+}
+
+#[test]
+fn live_cf_unaffected() {
+    let (_dir, db) = open_versioned();
+
+    // K1 written at every version 0..=9, K2 only at v=0..=5, K3 only at v=7..=9.
+    for v in 0..=9u64 {
+        let mut entries: Vec<(&[u8], u32)> = vec![(b"K1", v as u32)];
+        if v <= 5 {
+            entries.push((b"K2", v as u32));
+        }
+        if v >= 7 {
+            entries.push((b"K3", v as u32));
+        }
+        put_at(&db, &entries, v);
+    }
+    // Sanity: K2 was deleted at v=9 to exercise the live-CF delete-tombstone path.
+    delete_at(&db, &[b"K2"], 9);
+
+    // Snapshot live values pre-prune.
+    let pre_k1 = live(&db, b"K1");
+    let pre_k2 = live(&db, b"K2");
+    let pre_k3 = live(&db, b"K3");
+
+    let out = db.collect_pruning_batch(3, None).unwrap();
+    commit_pruning_batch(&db, &out.batch);
+
+    // Live values must be identical to pre-prune.
+    assert_eq!(live(&db, b"K1"), pre_k1);
+    assert_eq!(live(&db, b"K2"), pre_k2);
+    assert_eq!(live(&db, b"K3"), pre_k3);
+}


### PR DESCRIPTION
Prerequisite for https://github.com/Sovereign-Labs/sovereign-sdk/pull/2886


This PR adds pruning support for VersionedDB: callers can collect and commit archival cleanup batches that remove old historical rows, clear processed pruning-index entries, record a pruning watermark, and optionally compact affected archival column families to reclaim disk.

## Why

Versioned tables currently keep historical data indefinitely. This PR lets users bound retained history while preserving the invariant that live keys still have a surviving historical anchor for recent queries.

## Main Decisions

- merge specialized from generic `SchemaBatch<K,V>` to `SchemaBatch<SchemaKey, V>`, via a new RangeDeleteKey trait whose "next key" = append 0x00. Drops generality, but only Vec<u8> keys are used and the split needs byte-successor semantics.
- Hot-path key encoding duplicated as free functions (encode_archival_key / encode_pruning_key) instead of routing through KeyWithVersionPrefixAndSuffix. Layout-drift risk is pinned by a unit test (encode_helpers_match_key_with_version_layout).
- Capped passes buffer + sort collected entries in memory (bounded by max_batch_size) rather than streaming. The pruning tombstone's upper bound is the exact successor of the last collected entry — tighter than the old break-point
bound, removing stranded-entry / orphaned-row risk.
- Raw lookups stay non-watermark-aware by design: get_historical_value / get_version_for_key can return a "survivor" below the watermark; watermark-aware reads go through VersionedDeltaReader. Documented and locked by a test.

- Pruning is explicit and batched via collect_pruning_batch; callers commit the returned `SchemaBatch`.
- The pruning CF is cleared with range tombstones for efficiency.
- Historical CF deletes remain point deletes because rows are scattered by key.
- Capped pruning is supported with `max_batch_size`; large backlogs can be drained over multiple passes.
- `PrunedVersion` is a reader watermark, not proof that every old row is gone. Raw historical lookups may still see survivor rows below it; `VersionedDeltaReader` enforces the watermark.
- `SchemaBatch::merge` now preserves range deletes and splits earlier range deletes around later puts to maintain last-write-wins semantics.